### PR TITLE
Fix critical correctness bugs for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Correctness release. Every fix below changes externally observable behavior.
 - The adaptive threshold no longer chases sustained blocking. ~120 blocks of
   ~70ms used to yield ~9 detections and a final threshold near 380ms;
   detection now keeps firing for the whole run.
+- Adaptive mode no longer discards a calibration-tightened threshold. Its
+  floor used to be pinned at the fallback and its first update fired
+  immediately, snapping a calibrated 10ms threshold back to 50ms on the
+  first tick. The floor now follows the calibrated threshold.
 - Responses using ASGI extension messages no longer hang in strict mode:
   `http.response.pathsend` (Starlette `FileResponse` on Hypercorn/Granian),
   `http.response.trailers`, and unknown message types now pass through.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.5.0 (2026-08-11)
+
+Correctness release. Every fix below changes externally observable behavior.
+
+- `dev_mode` no longer turns blocking into 503s. Previously, one endpoint's
+  sync block made every concurrent innocent request fail with 503 while the
+  actual culprit returned 200. `dev_mode` now only adds diagnostic headers;
+  a 503 requires explicitly setting `enforcement_mode="strict"`. Docs no
+  longer claim the library identifies which endpoint caused blocking — it
+  reports the requests that were in flight during the stall.
+- A single blocking event is reported once, not twice. A 300ms block used to
+  produce two events summing to ~600ms in headers and logs (single-shot plus
+  a cumulative re-count of the same sample). Cumulative window sums are now
+  recorded separately from individual lag samples.
+- Calibration can no longer be poisoned by the app's own blocking. Background
+  calibration during a busy blocking startup used to raise the detection
+  threshold to ~8x the fallback, after which real blocking went undetected.
+  A calibrated threshold now only ever tightens the fallback.
+- The adaptive threshold no longer chases sustained blocking. ~120 blocks of
+  ~70ms used to yield ~9 detections and a final threshold near 380ms;
+  detection now keeps firing for the whole run.
+- Responses using ASGI extension messages no longer hang in strict mode:
+  `http.response.pathsend` (Starlette `FileResponse` on Hypercorn/Granian),
+  `http.response.trailers`, and unknown message types now pass through.
+- `"trailers": True` and any other key on `http.response.start` survive
+  header injection instead of being silently dropped.
+- The monitor no longer leaks background tasks when startup fails
+  (`lifespan.startup.failed` / `lifespan.shutdown.failed` now stop it), and a
+  lazily started monitor (apps without lifespan, e.g. tests using
+  `httpx.ASGITransport`) stops when the last in-flight request finishes.
+- `__version__` now matches the installed package metadata (it was hard-coded
+  to 0.3.0 while the package shipped as 0.4.1), and the 503 error page links
+  to the real repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,76 +4,106 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-fastapi-loopguard is a middleware library that detects event-loop blocking in FastAPI/Starlette applications with per-request attribution. It identifies when synchronous operations (like `time.sleep()`, blocking I/O, or CPU-bound code) block the async event loop and reports which request was responsible.
+fastapi-loopguard — a middleware library that detects event-loop blocking in FastAPI/Starlette apps with per-request attribution. When synchronous code (`time.sleep`, blocking I/O, CPU-bound work) freezes the async event loop, LoopGuard reports which requests were in flight and, depending on enforcement mode, warns, logs, or fails the response with an educational 503.
 
-## Development Commands
+**Division of docs — do not duplicate them here.** `README.md` owns the pitch, install, and quick-start snippet. `docs/CONFIGURATION.md` is the authoritative reference for every `LoopGuardConfig` option and the recommended recipes; add new options there. This file owns architecture, invariants, and workflow.
+
+There is no CONTRIBUTING.md. Release history lives in `CHANGELOG.md` (since 0.5.0) and in git tags (`v0.3.0` …).
+
+## Quick Start
 
 ```bash
-# Install dependencies (including dev tools)
-pip install -e ".[dev]"
+pip install -e ".[dev]"                  # dev deps: pytest, mypy, ruff, coverage, httpx, fastapi
+pytest                                   # full suite (asyncio_mode=auto, testpaths=tests)
+pytest tests/test_middleware.py::TestLoopGuardMiddleware::test_dev_mode_headers   # one test
+mypy src/                                # strict mode, src/ only
+ruff check src/ tests/                   # lint — CI runs this exact scope
+ruff format --check src/ tests/          # CI verifies formatting; drop --check to rewrite
+coverage run -m pytest tests/ && coverage report --fail-under=80   # the CI gate
 
-# Run tests
-pytest
-
-# Run single test
-pytest tests/test_middleware.py::TestLoopGuardMiddleware::test_dev_mode_headers
-
-# Type checking (strict mode)
-mypy src/
-
-# Linting and formatting
-ruff check src/ tests/
-ruff format src/ tests/
-
-# Coverage
-coverage run -m pytest && coverage report
+pip install -e ".[stress]"               # everything under examples/ needs uvicorn + locust
+python examples/demo_app.py              # demo on :8765 — /api/users returns 503 (dev_mode)
+python examples/stress_app.py            # stress target on :8000
+python examples/run_stress_test.py --skip-locust   # validation suite against a running :8000
 ```
+
+CI lints and type-checks `src/` and `tests/` only — `examples/` is unchecked and does not satisfy the `ANN` rules the rest of the tree does. `tests/test_metrics.py` skips entirely unless `.[prometheus]` is installed, which is why `metrics.py` reports 0% coverage on a plain `.[dev]` run; the 80% gate still passes at ~88% overall.
+
+## Tech Stack (versions verified 2026-08-11)
+
+- Python `>=3.12`; CI matrix is 3.12 and 3.13. mypy is pinned to `python_version = "3.12"` with `strict = true`.
+- **One runtime dependency: `starlette>=0.37.0,<1.0`.** FastAPI is a *dev* dependency — the middleware is pure ASGI and must never import `fastapi` from `src/`. Adding any runtime dependency requires asking first.
+- Extras: `prometheus` (prometheus-client), `structlog`, `all`, `dev`, `stress` (locust + uvicorn). The `structlog` extra is currently declared but unused — nothing imports structlog.
+- ruff selects `["E","F","I","N","W","UP","B","C4","SIM","ANN"]`, ignoring only `ANN401`. **`ANN` means every function needs full annotations**, tests and fixtures included. Line length 88, double quotes.
+- Build backend is hatchling; wheel packages `src/fastapi_loopguard`. Publishing triggers on a `v*` tag via PyPI trusted publishing (OIDC) — there is **no version-bump automation**, so `pyproject.toml` must be bumped by hand. `__init__.__version__` is derived from installed package metadata; after bumping, re-run `pip install -e .` or the version tests fail against stale metadata.
+- `.claude/` is git-ignored and excluded from the sdist. Committing anything there needs an explicit `.gitignore` negation.
 
 ## Architecture
 
-### Core Components
+```
+src/fastapi_loopguard/
+  config.py         LoopGuardConfig — frozen slotted dataclass + __post_init__ validation
+  context.py        RequestContext, RequestRegistry, module-global _registry, free functions
+  monitor.py        SentinelMonitor sleep-measure loop, AdaptiveThreshold
+  middleware.py     pure-ASGI LoopGuardMiddleware, enforcement modes, HTML/JSON error pages
+  logging.py        StructuredFormatter (JSON), configure_logging, log_blocking_event
+  metrics.py        optional Prometheus LoopGuardMetrics (see Known Gaps — not wired in)
+  pytest_plugin.py  pytest11 entry point, @pytest.mark.no_blocking, BlockingDetector
+```
 
-**LoopGuardMiddleware** (`middleware.py`): Pure ASGI middleware (no BaseHTTPMiddleware) that:
-- Handles ASGI lifespan events for proper startup/shutdown of the monitor
-- Registers request contexts for attribution via `RequestRegistry`
-- Injects debug headers (X-Request-Id, X-Blocking-Count, etc.) in dev mode via send wrapper
+**Layering (strict — a module imports only lower layers):** `config`, `context` → `monitor` → `middleware`. `logging`, `metrics`, and `pytest_plugin` are leaves; nothing on the detection path imports them, and they must not import `middleware`. `middleware.py` imports `LoopGuardConfig` inside `__init__` with an "avoid circular imports" comment — the cycle no longer exists, but the deferred import is harmless and not worth churning.
 
-**SentinelMonitor** (`monitor.py`): Background async task that detects blocking by:
-1. Sleeping for short intervals (default 10ms)
-2. Measuring actual elapsed time vs expected time
-3. If lag exceeds threshold (baseline × multiplier), blocking occurred
-4. Attributes blocking to ALL active requests since we can't determine the specific cause
+`pytest_plugin.py` is registered as a `pytest11` entry point, so it auto-loads for **every** project that installs this package. Treat its hooks as public API and keep them cheap and side-effect-free for unmarked tests.
 
-**RequestRegistry** (`context.py`): Thread-safe (via single-threaded asyncio) registry tracking concurrent requests. Uses dict keyed by request_id. When blocking is detected, the monitor iterates all active contexts.
+**Detection flow:** ASGI `lifespan.startup` starts the monitor → `_handle_http` skips `exclude_paths`, then registers a `RequestContext` and writes the id to `scope["state"]["loopguard_request_id"]` → `_monitor_loop` sleeps `monitor_interval_ms` and computes `lag_ms = (elapsed - interval) * 1000` → lag over threshold calls `_handle_blocking`, which calls `record_blocking` on every active context → the send wrapper reads `ctx.blocking_count` / `ctx.total_blocking_ms` and emits headers or a 503 → `finally` unregisters (and stops a lazily started monitor once the registry empties) → any terminal lifespan message (`shutdown.complete`, `shutdown.failed`, `startup.failed`) stops the monitor.
 
-**LoopGuardConfig** (`config.py`): Frozen dataclass with validation. Key settings:
-- `monitor_interval_ms`: Check frequency (default 10ms)
-- `threshold_multiplier`: Blocking = lag > baseline × multiplier (default 5.0)
-- `dev_mode`: Enables X-Blocking-* response headers
-- `adaptive_threshold`: Enable sliding-window based automatic threshold adjustment (v0.3.0+)
+## Detection Invariants (non-negotiable)
 
-**AdaptiveThreshold** (`monitor.py`): Sliding window percentile-based threshold calculator:
-- Maintains a bounded deque of recent lag samples (`adaptive_window_size`)
-- Recalculates threshold as `P{adaptive_percentile} × multiplier`
-- Only activates after `adaptive_min_samples` collected
-- Reduces false positives in high-concurrency environments
+1. **Pure ASGI — never `BaseHTTPMiddleware`.** It is deprecated, breaks contextvars, and leaks memory. `__call__` dispatches on `scope["type"]`; WebSocket and every other type pass through untouched, with no context registered.
+2. **Blocking attributes to ALL active requests.** The sentinel measures loop lag, not call stacks, so it cannot know which request blocked. `_handle_blocking` iterates every context from `get_active_requests()` and records the same lag on each. This over-reports under concurrency **by design** — narrowing it is a redesign, not a bug fix.
+3. **The registry needs no locks.** asyncio is single-threaded, so `RequestRegistry` is a plain dict keyed by `request_id`. Never add a lock, a `threading` primitive, or thread-safety without first changing that premise and saying so.
+4. **Calibration never blocks the first request, and can only tighten.** `start_with_background_calibration()` starts `_monitor_loop` immediately on `fallback_threshold_ms` and calibrates in a named background task. Baseline is the **minimum** of `calibration_iterations` samples (the idle floor — robust to contamination from live traffic), and the calibrated threshold is clamped to `[monitor_interval_ms, fallback_threshold_ms]`: it may lower the fallback, never raise it. The adaptive window is censored (only sub-threshold samples admitted) and its floor follows the calibrated threshold, so neither calibration nor adaptation can be poisoned upward by the app's own blocking. A failed or cancelled calibration keeps the fallback threshold and must never raise into startup.
+5. **Unregister always runs.** `_handle_http` wraps dispatch in `try/finally: unregister_request(request_id)`. An exception from the wrapped app must never leak a context into the registry — a leak makes every later blocking event attribute to a dead request forever.
+6. **`dev_mode` is headers-only; a 503 requires explicit strict mode.** `_get_effective_enforcement_mode()` always returns `enforcement_mode` — `dev_mode` never changes it. Because blocking is attributed to ALL in-flight requests (invariant 2), a status change punishes innocent bystanders, so it must stay opt-in via `enforcement_mode="strict"`. No text anywhere may claim the library identifies WHICH endpoint blocked — it narrows it to the requests in flight during the stall.
+7. **One blocking event is reported exactly once.** A sample that fires the single-shot detection is never appended to `_lag_history`, within one `_monitor_loop` iteration a single-lag trigger suppresses the cumulative one, and `_lag_history` is cleared after a cumulative fire so a window reports at most once. Cumulative window sums are recorded in `RequestContext.cumulative_events`, separate from the individual-lag `blocking_events` list; `blocking_count` / `total_blocking_ms` sum both.
+8. **Lifecycle calls are idempotent, and lazy monitors stop when idle.** `start()`, `start_with_background_calibration()`, and `stop()` all return early when already in the target state. `_handle_http` lazily starts the monitor for apps that run without ASGI lifespan and stops it when the last in-flight request unregisters (so `httpx.ASGITransport` tests leak no tasks); lifespan-managed monitors persist between requests. Double-start must stay a no-op. Consequence: in lazy mode background calibration rarely completes and the fallback threshold governs.
 
-### Blocking Detection Flow
+## Conventions
 
-1. Middleware registers `RequestContext` in global `RequestRegistry`
-2. `SentinelMonitor` runs continuous sleep-measure loop
-3. On startup: background calibration measures baseline latency (P75 of samples)
-4. When lag > threshold: `_handle_blocking()` iterates all active contexts via `get_active_requests()`
-5. Each context's `record_blocking()` appends event to `blocking_events` list
-6. On response: middleware reads context stats and adds headers
+- **`LoopGuardConfig` is frozen — never mutate it, construct a new one.** All validation lives in `__post_init__` and raises `ValueError` with a message naming the field.
+- Every new config option needs three things: a validation rule in `__post_init__`, a case in `TestLoopGuardConfig`, and a row in `docs/CONFIGURATION.md`. Missing any one of them is an incomplete change.
+- **Response headers are lowercase bytes.** Pass-through responses carry `x-request-id`, `x-blocking-count`, `x-blocking-total-ms`, and `x-blocking-detected`, plus `x-loopguard-warning: blocking-detected` in warn mode. The strict 503 built by `_send_strict_error` carries `x-loopguard-enforcement: strict` and **omits `x-blocking-detected`** — a separate header set, not an extension of the first.
+- `request_id` is the first 8 characters of a `uuid4` — short enough to read in a terminal, not a security token.
+- **All internal timing uses `loop.time()` or `time.monotonic()`** — never `datetime` or wall-clock, which jump under NTP.
+- Hot-path classes use `__slots__`: `LoopGuardConfig`, `RequestContext`, `RequestRegistry`, `SentinelMonitor`, `AdaptiveThreshold`, `LoopGuardMiddleware`. Adding an attribute means adding it to `__slots__`, and `test_context.py` asserts the absence of `__dict__`.
+- Logger name is `"fastapi_loopguard"`, shared by `monitor.py` and `logging.py`. `monitor.py` logs inline with `%`-style lazy formatting; `logging.log_blocking_event()` is a helper for library *users* and is intentionally not called internally.
+- `exclude_paths` is checked before anything else in `_handle_http`, so health checks cost nothing.
+- Backward-compat shims are public API and stay: `get_current_request`, `set_current_request`, `reset_current_request`, `init_metrics`. `get_current_request` returns an arbitrary active context and is only correct for single-request cases — new code uses `get_active_requests()`.
+- `logging`, `metrics`, and `pytest_plugin` are **not** re-exported from `__init__.py`; import them by module path.
 
-### Optional Components
+## Testing
 
-- **Prometheus metrics** (`metrics.py`): Optional `prometheus_client` integration
-- **pytest plugin** (`pytest_plugin.py`): `@pytest.mark.no_blocking` marker fails tests that block
+- Definition of done: `pytest` green, `mypy src/` clean, `ruff check src/ tests/` and `ruff format --check src/ tests/` clean, and coverage at or above **80** (`--fail-under=80` is the CI gate).
+- **There is no `conftest.py`.** The `clear_registry` fixture is duplicated per file, roughly 15 times. Match the local pattern in the file you are editing; introducing a shared conftest is its own change, not a side effect of an unrelated one.
+- Blocking is simulated with `time.sleep(...)` followed by a short `await asyncio.sleep(...)` — the second call is what lets the sentinel observe the lag while the context is still registered. Omitting it makes the test pass for the wrong reason.
+- HTTP tests use `httpx.AsyncClient(transport=ASGITransport(app=app))`. Plugin tests use the `pytester` fixture to run generated test files in-process.
+- Each invariant has dedicated coverage: `test_enforcement_mode.py` for modes and dev-mode escalation, `test_monitor.py` for calibration, idempotency, and task cancellation, `test_cumulative_blocking.py` for the window, `test_context.py` for registry lifecycle and `__slots__`, `test_pytest_plugin.py` for the marker.
+- Timing tests are inherently flaky under load. Prefer driving `SentinelMonitor` directly with an `on_blocking` callback (as `test_cumulative_blocking.py` does) over asserting on wall-clock durations.
 
-## Test Configuration
+## Known Gaps (accurate as of 2026-08-11)
 
-- Uses `pytest-asyncio` with `asyncio_mode = "auto"` and `asyncio_default_fixture_loop_scope = "function"`
-- Tests use `httpx.AsyncClient` with `ASGITransport` for testing ASGI apps
-- Each test clears the global `RequestRegistry` via `clear_registry` fixture
+Recorded so they are not rediscovered. None are fixed yet; fixing any of them is its own task. The fuller list, including design tensions deferred from the 0.5 correctness pass, is `FINDINGS.md`.
+
+1. **`prometheus_enabled` is inert.** Neither `middleware.py` nor `monitor.py` imports `metrics.py`, so enabling the flag exposes nothing. Wiring it up means calling `record_blocking` / `record_request` / `set_threshold` from the monitor.
+2. **`docs/CONFIGURATION.md` names metrics that do not exist.** It lists `loopguard_blocking_events_total` and `loopguard_blocking_duration_ms`; the real names are `loopguard_blocking_total`, `loopguard_lag_seconds`, `loopguard_requests_monitored_total`, and `loopguard_threshold_seconds`.
+3. **`get_metrics()` can never find an instance.** It reads `_instances[prefix]` while `create_metrics` writes `f"{prefix}:{id(registry)}"`. `tests/test_metrics.py:188` documents the mismatch in a comment instead of failing on it.
+4. **`_generate_warning_banner()` is dead code** — defined in `middleware.py`, never called.
+
+## Fundamental Guidelines
+
+*(Distilled from [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills))*
+
+- **Think first.** Surface assumptions and tradeoffs; if a request is ambiguous or a simpler approach exists, say so before coding — don't pick silently.
+- **Simplicity first.** Minimum code that solves the problem. No speculative features, abstractions, config, or error handling for impossible cases.
+- **Surgical changes.** Touch only what the task requires. Match existing style, don't refactor working code, remove only orphans your own change created.
+- **Goal-driven.** Turn tasks into verifiable goals (e.g. "fix bug" → "write a failing test, make it pass"); state a brief plan for multi-step work.

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,88 @@
+# Findings not fixed in the 0.5 pass
+
+Everything noticed while fixing the 0.5 correctness defects but deliberately
+left alone. Each item is its own future task.
+
+## Detection design
+
+1. **Adaptive threshold discards the calibrated threshold.**
+   `AdaptiveThreshold` is constructed with `min_threshold_ms = fallback_threshold_ms`
+   and `recalculate()` returns `_current_threshold_ms` even below `min_samples`.
+   Because `_last_adapt_time` starts at `0.0`, the first monitor iteration
+   immediately overwrites a calibration-tightened threshold (e.g. 10ms) back to
+   the 50ms fallback. Calibration and adaptive mode fight each other; adaptive
+   effectively wins on the first tick.
+
+2. **Sub-threshold noise can still inflate the adaptive threshold.**
+   The 0.5 fix censors detected-blocking samples out of the window, but samples
+   just below the threshold are admitted by design, and
+   `P95 x threshold_multiplier` of ~40ms noise still produces a ~230ms
+   threshold that would mask a later 100ms block. Per the forensics guidance,
+   median+MAD over the censored window would be more robust than a percentile.
+
+3. **Strict mode cannot fail a response after `http.response.start` has passed.**
+   If blocking is first detected mid-stream, the 200 and its headers are
+   already on the wire and the body keeps streaming; the response then claims
+   no blocking. Inherent to header-based reporting; worth documenting.
+
+4. **Explicit strict mode still 503s all in-flight requests.**
+   The sentinel cannot name the culprit, so strict mode punishes bystanders
+   under concurrency. Now opt-in and documented, but the real per-callback
+   attribution rewrite (the 0.5+ plan) is what removes this.
+
+5. **Lazy mode (no ASGI lifespan) rarely completes calibration.**
+   The stop-when-idle lifecycle cancels background calibration when the last
+   request finishes, so lifespan-less deployments run on the fallback
+   threshold and have no between-request monitoring. Accepted tradeoff for
+   not leaking tasks; worth a README note if such deployments matter.
+
+## ASGI / architecture
+
+6. **`exclude_paths` matches the raw `scope["path"]`.**
+   Breaks under `root_path` and `Mount`, and `/health/live` is not excluded by
+   `/health`. Prefix or route-template matching would fix it.
+
+7. **Module-global `RequestRegistry` breaks with two apps in one process.**
+   A mounted sub-app or a second middleware-wrapped app cross-attributes
+   blocking between apps. Keying state per middleware instance (or per loop)
+   would fix it.
+
+8. **The package could be zero-dependency.**
+   `middleware.py` imports only type aliases from `starlette.types`; moving
+   that import under `TYPE_CHECKING` removes the runtime dependency entirely
+   (works on Litestar, Quart, Django ASGI, ...). Also, the `<1.0` upper bound
+   on starlette will block installs the day Starlette 1.0 ships.
+
+9. **`get_current_request()` returns an arbitrary active context.**
+   A backward-compat shim that silently gives wrong answers under concurrency.
+   Pre-1.0 with few users, removal is cheaper than the confusion.
+
+## Dead / inert code and docs drift
+
+10. **`prometheus_enabled` is inert** (known gap #3): nothing on the detection
+    path imports `metrics.py`. Out of scope here (`metrics.py` untouchable).
+
+11. **`_generate_warning_banner()` is dead code** (known gap #6).
+
+12. **`docs/CONFIGURATION.md` names metrics that do not exist** (known gap #4)
+    and `get_metrics()` can never find an instance (known gap #5).
+
+13. **Docs drift created by the 0.5 fixes themselves:**
+    - `CLAUDE.md` invariant 4 (P75 baseline), invariant 6 (dev_mode
+      escalation), and known gaps 1-2 describe pre-0.5 behavior. CLAUDE.md has
+      uncommitted local edits, so it was left untouched.
+    - `docs/CONFIGURATION.md` describes `fallback_threshold_ms` as "Used if
+      calibration is unreliable"; since 0.5 it is the hard ceiling for the
+      calibrated threshold.
+
+14. **`_handle_lifespan` locals `started` / `shutdown_complete` are write-only.**
+
+15. **The `structlog` extra is declared but nothing imports structlog**
+    (already noted in CLAUDE.md).
+
+## Repro caveat worth keeping
+
+16. **Calibration poisoning (defect 2) required blocking to span the whole
+    calibration window.** With idle gaps, clean tail samples dominated and the
+    old `max(..., fallback)` floor masked the bug. The fix removes the
+    mechanism either way, but tests that "prove" poisoning need dense blocking.

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -5,32 +5,24 @@ left alone. Each item is its own future task.
 
 ## Detection design
 
-1. **Adaptive threshold discards the calibrated threshold.**
-   `AdaptiveThreshold` is constructed with `min_threshold_ms = fallback_threshold_ms`
-   and `recalculate()` returns `_current_threshold_ms` even below `min_samples`.
-   Because `_last_adapt_time` starts at `0.0`, the first monitor iteration
-   immediately overwrites a calibration-tightened threshold (e.g. 10ms) back to
-   the 50ms fallback. Calibration and adaptive mode fight each other; adaptive
-   effectively wins on the first tick.
-
-2. **Sub-threshold noise can still inflate the adaptive threshold.**
-   The 0.5 fix censors detected-blocking samples out of the window, but samples
-   just below the threshold are admitted by design, and
+1. **Sub-threshold noise can still inflate the adaptive threshold.**
+   The 0.5 fix censors detected-blocking samples out of the window, but
+   samples just below the threshold are admitted by design, and
    `P95 x threshold_multiplier` of ~40ms noise still produces a ~230ms
    threshold that would mask a later 100ms block. Per the forensics guidance,
    median+MAD over the censored window would be more robust than a percentile.
 
-3. **Strict mode cannot fail a response after `http.response.start` has passed.**
+2. **Strict mode cannot fail a response after `http.response.start` has passed.**
    If blocking is first detected mid-stream, the 200 and its headers are
    already on the wire and the body keeps streaming; the response then claims
    no blocking. Inherent to header-based reporting; worth documenting.
 
-4. **Explicit strict mode still 503s all in-flight requests.**
+3. **Explicit strict mode still 503s all in-flight requests.**
    The sentinel cannot name the culprit, so strict mode punishes bystanders
    under concurrency. Now opt-in and documented, but the real per-callback
    attribution rewrite (the 0.5+ plan) is what removes this.
 
-5. **Lazy mode (no ASGI lifespan) rarely completes calibration.**
+4. **Lazy mode (no ASGI lifespan) rarely completes calibration.**
    The stop-when-idle lifecycle cancels background calibration when the last
    request finishes, so lifespan-less deployments run on the fallback
    threshold and have no between-request monitoring. Accepted tradeoff for
@@ -38,51 +30,55 @@ left alone. Each item is its own future task.
 
 ## ASGI / architecture
 
-6. **`exclude_paths` matches the raw `scope["path"]`.**
+5. **`exclude_paths` matches the raw `scope["path"]`.**
    Breaks under `root_path` and `Mount`, and `/health/live` is not excluded by
    `/health`. Prefix or route-template matching would fix it.
 
-7. **Module-global `RequestRegistry` breaks with two apps in one process.**
+6. **Module-global `RequestRegistry` breaks with two apps in one process.**
    A mounted sub-app or a second middleware-wrapped app cross-attributes
    blocking between apps. Keying state per middleware instance (or per loop)
    would fix it.
 
-8. **The package could be zero-dependency.**
+7. **The package could be zero-dependency.**
    `middleware.py` imports only type aliases from `starlette.types`; moving
    that import under `TYPE_CHECKING` removes the runtime dependency entirely
    (works on Litestar, Quart, Django ASGI, ...). Also, the `<1.0` upper bound
    on starlette will block installs the day Starlette 1.0 ships.
 
-9. **`get_current_request()` returns an arbitrary active context.**
+8. **`get_current_request()` returns an arbitrary active context.**
    A backward-compat shim that silently gives wrong answers under concurrency.
    Pre-1.0 with few users, removal is cheaper than the confusion.
 
 ## Dead / inert code and docs drift
 
-10. **`prometheus_enabled` is inert** (known gap #3): nothing on the detection
-    path imports `metrics.py`. Out of scope here (`metrics.py` untouchable).
+9. **`prometheus_enabled` is inert** (known gap #1): nothing on the detection
+   path imports `metrics.py`. Out of scope here (`metrics.py` untouchable).
 
-11. **`_generate_warning_banner()` is dead code** (known gap #6).
+10. **`_generate_warning_banner()` is dead code** (known gap #4).
 
-12. **`docs/CONFIGURATION.md` names metrics that do not exist** (known gap #4)
-    and `get_metrics()` can never find an instance (known gap #5).
+11. **`docs/CONFIGURATION.md` names metrics that do not exist** (known gap #2)
+    and `get_metrics()` can never find an instance (known gap #3).
 
-13. **Docs drift created by the 0.5 fixes themselves:**
-    - `CLAUDE.md` invariant 4 (P75 baseline), invariant 6 (dev_mode
-      escalation), and known gaps 1-2 describe pre-0.5 behavior. CLAUDE.md has
-      uncommitted local edits, so it was left untouched.
-    - `docs/CONFIGURATION.md` describes `fallback_threshold_ms` as "Used if
-      calibration is unreliable"; since 0.5 it is the hard ceiling for the
-      calibrated threshold.
+12. **`docs/CONFIGURATION.md` describes `fallback_threshold_ms` as "Used if
+    calibration is unreliable"**; since 0.5 it is also the hard ceiling for
+    the calibrated threshold.
 
-14. **`_handle_lifespan` locals `started` / `shutdown_complete` are write-only.**
+13. **`_handle_lifespan` locals `started` / `shutdown_complete` are write-only.**
 
-15. **The `structlog` extra is declared but nothing imports structlog**
+14. **The `structlog` extra is declared but nothing imports structlog**
     (already noted in CLAUDE.md).
 
 ## Repro caveat worth keeping
 
-16. **Calibration poisoning (defect 2) required blocking to span the whole
+15. **Calibration poisoning (defect 2) required blocking to span the whole
     calibration window.** With idle gaps, clean tail samples dominated and the
     old `max(..., fallback)` floor masked the bug. The fix removes the
     mechanism either way, but tests that "prove" poisoning need dense blocking.
+
+## Fixed since the first draft
+
+- Adaptive mode discarding the calibrated threshold (floor pinned at the
+  fallback, first update firing immediately) — fixed on this branch; the
+  adaptive floor now follows the calibrated threshold.
+- CLAUDE.md invariants 4 and 6 and known gaps 1-2 describing pre-0.5
+  behavior — CLAUDE.md updated on this branch.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Catch event-loop blocking in FastAPI with per-request attribution.</strong>
+  <strong>Catch event-loop blocking in FastAPI and see which requests were in flight.</strong>
 </p>
 
 <p align="center">
@@ -14,7 +14,7 @@
 
 ---
 
-When a request blocks your event loop (via `time.sleep()`, blocking I/O, or CPU work), LoopGuard detects it **and tells you which endpoint caused it**.
+When something blocks your event loop (via `time.sleep()`, blocking I/O, or CPU work), LoopGuard detects it **and narrows it down to the requests that were in flight when the loop stalled**. The sentinel measures loop lag, so it cannot name the single guilty handler — it reports every request that was active during the stall.
 
 ## Install
 
@@ -43,8 +43,11 @@ app.add_middleware(LoopGuardMiddleware)
 ```python
 from fastapi_loopguard import LoopGuardConfig
 
-# Development: strict enforcement (503 on blocking)
+# Development: diagnostic headers on every response
 config = LoopGuardConfig(dev_mode=True)
+
+# Development / CI: fail loudly with an educational 503
+config = LoopGuardConfig(enforcement_mode="strict")
 
 # Production: silent logging
 config = LoopGuardConfig(enforcement_mode="log")
@@ -73,7 +76,7 @@ Adds diagnostic headers to every response for debugging:
 ---
 
 ### Log Mode
-Writes structured logs with full request attribution:
+Writes structured logs listing the requests that were in flight:
 
 <p align="center">
   <img src="assets/error-page-screenshot-console.png" alt="Console output" width="600" />

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,7 +10,7 @@ from fastapi_loopguard import LoopGuardConfig
 config = LoopGuardConfig(
     # Enforcement
     enforcement_mode="warn",      # "log" | "warn" | "strict"
-    dev_mode=False,               # Auto-escalates to strict when True
+    dev_mode=False,               # Adds X-Blocking-* response headers when True
 
     # Detection tuning
     monitor_interval_ms=10.0,     # How often to check (ms)
@@ -39,7 +39,7 @@ config = LoopGuardConfig(
 |--------|------|---------|-------------|
 | `enabled` | bool | `True` | Master switch. Set `False` to disable entirely. |
 | `enforcement_mode` | str | `"warn"` | How to respond: `"log"`, `"warn"`, or `"strict"` |
-| `dev_mode` | bool | `False` | Enables response headers. Auto-escalates to strict mode. |
+| `dev_mode` | bool | `False` | Enables response headers. Never changes the enforcement mode. |
 | `log_blocking_events` | bool | `True` | Log blocking events to console |
 | `exclude_paths` | frozenset | `{"/health", ...}` | Paths to skip monitoring |
 
@@ -98,9 +98,14 @@ When enabled, exposes:
 
 ## Common Configurations
 
-### Development (strict enforcement)
+### Development (diagnostic headers)
 ```python
 config = LoopGuardConfig(dev_mode=True)
+```
+
+### Development / CI (strict enforcement, 503 on blocking)
+```python
+config = LoopGuardConfig(enforcement_mode="strict")
 ```
 
 ### Production (silent monitoring)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi-loopguard"
-version = "0.4.1"
+version = "0.5.0"
 description = "Detect event-loop blocking in FastAPI/Starlette with per-request attribution"
 readme = "README.md"
 license = "MIT"

--- a/src/fastapi_loopguard/__init__.py
+++ b/src/fastapi_loopguard/__init__.py
@@ -29,6 +29,8 @@ v0.3.0 Changes:
     - High-concurrency configuration documentation
 """
 
+from importlib.metadata import version as _package_version
+
 from .config import LoopGuardConfig
 from .context import (
     RequestContext,
@@ -42,7 +44,7 @@ from .context import (
 from .middleware import LoopGuardMiddleware
 from .monitor import SentinelMonitor
 
-__version__ = "0.3.0"
+__version__ = _package_version("fastapi-loopguard")
 
 __all__ = [
     # Core classes

--- a/src/fastapi_loopguard/__init__.py
+++ b/src/fastapi_loopguard/__init__.py
@@ -1,4 +1,8 @@
-"""FastAPI LoopGuard - Detect event-loop blocking with per-request attribution.
+"""FastAPI LoopGuard - Detect event-loop blocking and report in-flight requests.
+
+The sentinel measures event-loop lag, so it cannot identify the single
+handler that blocked; it attributes each stall to every request that was
+in flight at the time.
 
 Usage:
     from fastapi import FastAPI

--- a/src/fastapi_loopguard/context.py
+++ b/src/fastapi_loopguard/context.py
@@ -24,7 +24,10 @@ class RequestContext:
         path: The request path (e.g., "/api/users").
         method: HTTP method (GET, POST, etc.).
         start_time: Monotonic timestamp when request started.
-        blocking_events: List of (lag_ms, timestamp) tuples for blocking detected.
+        blocking_events: List of (lag_ms, timestamp) tuples, one per observed
+            lag sample that exceeded the threshold.
+        cumulative_events: List of (lag_ms, timestamp) tuples where lag_ms is
+            a window sum from cumulative detection, not an individual sample.
     """
 
     request_id: str
@@ -32,20 +35,30 @@ class RequestContext:
     method: str
     start_time: float = field(default_factory=time.monotonic)
     blocking_events: list[tuple[float, float]] = field(default_factory=list)
+    cumulative_events: list[tuple[float, float]] = field(default_factory=list)
 
-    def record_blocking(self, lag_ms: float) -> None:
-        """Record a blocking event for this request."""
-        self.blocking_events.append((lag_ms, time.monotonic()))
+    def record_blocking(self, lag_ms: float, cumulative: bool = False) -> None:
+        """Record a blocking event for this request.
+
+        Args:
+            lag_ms: The observed lag in milliseconds.
+            cumulative: True when lag_ms is a window sum from cumulative
+                detection rather than a single observed lag sample.
+        """
+        events = self.cumulative_events if cumulative else self.blocking_events
+        events.append((lag_ms, time.monotonic()))
 
     @property
     def total_blocking_ms(self) -> float:
-        """Sum of all blocking event durations."""
-        return sum(lag for lag, _ in self.blocking_events)
+        """Sum of all blocking event durations (individual and cumulative)."""
+        return sum(lag for lag, _ in self.blocking_events) + sum(
+            lag for lag, _ in self.cumulative_events
+        )
 
     @property
     def blocking_count(self) -> int:
-        """Number of blocking events detected."""
-        return len(self.blocking_events)
+        """Number of blocking events detected (individual and cumulative)."""
+        return len(self.blocking_events) + len(self.cumulative_events)
 
 
 class RequestRegistry:

--- a/src/fastapi_loopguard/middleware.py
+++ b/src/fastapi_loopguard/middleware.py
@@ -234,12 +234,8 @@ class LoopGuardMiddleware:
                     ]
                 )
 
-                # Create new message with updated headers
-                message = {
-                    "type": message["type"],
-                    "status": message.get("status", 200),
-                    "headers": headers,
-                }
+                # Copy the message so keys like "trailers" are preserved
+                message = {**message, "headers": headers}
 
             await send(message)
 
@@ -568,11 +564,7 @@ await proc.wait()
                         self._log_console_warning(ctx)
                         warning_logged = True
 
-                message = {
-                    "type": message["type"],
-                    "status": message.get("status", 200),
-                    "headers": headers,
-                }
+                message = {**message, "headers": headers}
 
             await send(message)
 
@@ -613,11 +605,7 @@ await proc.wait()
                     ]
                 )
 
-                message = {
-                    "type": message["type"],
-                    "status": message.get("status", 200),
-                    "headers": headers,
-                }
+                message = {**message, "headers": headers}
                 await send(message)
 
             elif blocking_detected:

--- a/src/fastapi_loopguard/middleware.py
+++ b/src/fastapi_loopguard/middleware.py
@@ -428,7 +428,7 @@ await proc.wait()
 
         <div class="footer">
             Request ID: {ctx.request_id} &bull;
-            Detected by <a href="https://github.com/pyhub-kr/fastapi-loopguard">LoopGuard</a>
+            Detected by <a href="https://github.com/parhamdavari/fastapi-loopguard">LoopGuard</a>
         </div>
     </div>
 </body>

--- a/src/fastapi_loopguard/middleware.py
+++ b/src/fastapi_loopguard/middleware.py
@@ -6,6 +6,7 @@ with BaseHTTPMiddleware (deprecated, breaks contextvars, memory leaks).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 import uuid
@@ -13,7 +14,12 @@ from typing import TYPE_CHECKING
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from .context import RequestContext, register_request, unregister_request
+from .context import (
+    RequestContext,
+    get_registry,
+    register_request,
+    unregister_request,
+)
 from .monitor import SentinelMonitor
 
 if TYPE_CHECKING:
@@ -44,7 +50,7 @@ class LoopGuardMiddleware:
     - Send wrapper for header injection
     """
 
-    __slots__ = ("app", "_config", "_monitor", "_started")
+    __slots__ = ("app", "_config", "_monitor", "_started", "_lazy_started")
 
     def __init__(
         self,
@@ -65,6 +71,7 @@ class LoopGuardMiddleware:
         self._config = config or ConfigClass()
         self._monitor: SentinelMonitor | None = None
         self._started = False
+        self._lazy_started = False
 
     async def __call__(
         self,
@@ -108,6 +115,7 @@ class LoopGuardMiddleware:
                 # Start monitor before signaling startup complete
                 if self._config.enabled and not self._started:
                     await self._start_monitor()
+                self._lazy_started = False
                 started = True
 
             return message
@@ -115,13 +123,15 @@ class LoopGuardMiddleware:
         async def send_wrapper(message: Message) -> None:
             nonlocal shutdown_complete
 
-            if message["type"] == "lifespan.shutdown.complete":
-                # Stop monitor after app signals shutdown complete
-                if self._monitor:
-                    await self._monitor.stop()
-                    self._monitor = None
-                    self._started = False
-                shutdown_complete = True
+            if message["type"] in (
+                "lifespan.startup.failed",
+                "lifespan.shutdown.complete",
+                "lifespan.shutdown.failed",
+            ):
+                # Stop monitor when the app shuts down OR fails to start;
+                # a failed startup must not leak the monitor tasks
+                await self._stop_monitor()
+                shutdown_complete = message["type"] == "lifespan.shutdown.complete"
 
             await send(message)
 
@@ -136,6 +146,14 @@ class LoopGuardMiddleware:
         # Use background calibration so first request isn't blocked
         await self._monitor.start_with_background_calibration()
         self._started = True
+
+    async def _stop_monitor(self) -> None:
+        """Stop the monitor and reset lifecycle state. Idempotent."""
+        if self._monitor:
+            await self._monitor.stop()
+            self._monitor = None
+        self._started = False
+        self._lazy_started = False
 
     async def _handle_http(
         self,
@@ -162,6 +180,10 @@ class LoopGuardMiddleware:
         # Lazy start for apps without lifespan events
         if not self._started:
             await self._start_monitor()
+            self._lazy_started = True
+            # Yield once so the monitor takes its first tick before dispatch;
+            # otherwise blocking before the app's first await is invisible
+            await asyncio.sleep(0)
 
         # Create and register request context
         request_id = str(uuid.uuid4())[:8]
@@ -196,6 +218,15 @@ class LoopGuardMiddleware:
                 await self.app(scope, receive, send)
         finally:
             unregister_request(request_id)
+            # A lazily started monitor has no lifespan shutdown to stop it:
+            # stop when the last in-flight request finishes, restart on the
+            # next request. Lifespan-managed monitors are left running.
+            if (
+                self._lazy_started
+                and self._started
+                and get_registry().active_count() == 0
+            ):
+                await self._stop_monitor()
 
     async def _handle_with_headers(
         self,

--- a/src/fastapi_loopguard/middleware.py
+++ b/src/fastapi_loopguard/middleware.py
@@ -620,10 +620,12 @@ await proc.wait()
                 }
                 await send(message)
 
-            elif message["type"] == "http.response.body":
-                if blocking_detected:
-                    # Skip original body - we'll send error response after
-                    return
+            elif blocking_detected:
+                # Skip the rest of the original response - the 503 replaces it
+                return
+
+            else:
+                # Body, trailers, pathsend, or any other message: pass through
                 await send(message)
 
         await self.app(scope, receive, send_wrapper)

--- a/src/fastapi_loopguard/middleware.py
+++ b/src/fastapi_loopguard/middleware.py
@@ -242,13 +242,13 @@ class LoopGuardMiddleware:
         await self.app(scope, receive, send_wrapper)
 
     def _get_effective_enforcement_mode(self) -> str:
-        """Get the effective enforcement mode, considering dev_mode escalation.
+        """Get the effective enforcement mode.
 
-        When dev_mode=True and enforcement_mode is not explicitly "log",
-        auto-escalate to "strict" for maximum learning impact.
+        dev_mode only controls debug headers and never changes the mode.
+        A 503 requires explicitly opting in with enforcement_mode="strict",
+        because blocking is attributed to ALL in-flight requests and a
+        status change would punish innocent concurrent requests.
         """
-        if self._config.dev_mode and self._config.enforcement_mode != "log":
-            return "strict"
         return self._config.enforcement_mode
 
     def _get_client_accepts_html(self, scope: Scope) -> bool:
@@ -265,12 +265,13 @@ class LoopGuardMiddleware:
   LOOPGUARD: Event Loop Blocked!
 {"!" * 72}
 
-  Request: {ctx.method} {ctx.path}
+  In-flight request: {ctx.method} {ctx.path}
   Request ID: {ctx.request_id}
   Blocked: {ctx.blocking_count} time(s), {ctx.total_blocking_ms:.1f}ms total
 
-  Your async code ran BLOCKING operations.
-  ALL other requests were frozen while waiting.
+  Blocking was detected while this request was in flight. The culprit
+  may be this request or any other concurrent request.
+  ALL requests were frozen while the event loop was blocked.
 
   Common fixes:
     time.sleep(n)       -> await asyncio.sleep(n)
@@ -360,7 +361,8 @@ class LoopGuardMiddleware:
         <div class="error-box">
             <h1>Event Loop Blocked!</h1>
             <p>
-                <strong>Request:</strong> <code>{ctx.method} {ctx.path}</code><br>
+                <strong>In-flight request:</strong>
+                <code>{ctx.method} {ctx.path}</code><br>
                 <strong>Blocked:</strong> {ctx.blocking_count} time(s),
                 totaling <code>{ctx.total_blocking_ms:.1f}ms</code>
             </p>
@@ -368,8 +370,9 @@ class LoopGuardMiddleware:
 
         <h2>What Happened?</h2>
         <p>
-            Your async endpoint executed <strong>synchronous (blocking) code</strong>
-            that froze the event loop. During this time, ALL other requests were
+            While this request was in flight, <strong>synchronous (blocking)
+            code</strong> froze the event loop &mdash; in this handler or in any
+            other concurrent request. During this time, ALL requests were
             waiting and couldn't be processed.
         </p>
 
@@ -435,7 +438,9 @@ await proc.wait()
         return json.dumps(
             {
                 "error": "event_loop_blocked",
-                "message": "Blocking operation detected in async endpoint",
+                "message": (
+                    "Event loop blocking detected while this request was in flight"
+                ),
                 "request": {
                     "id": ctx.request_id,
                     "method": ctx.method,

--- a/src/fastapi_loopguard/monitor.py
+++ b/src/fastapi_loopguard/monitor.py
@@ -189,8 +189,11 @@ class SentinelMonitor:
     async def calibrate(self) -> float:
         """Calibrate the baseline event loop latency.
 
-        Runs a series of sleep calls to measure the typical latency
-        of yielding to the event loop under normal conditions.
+        Runs a series of sleep calls and takes the MINIMUM observed lag as
+        the baseline: it estimates the idle floor and is the sample least
+        affected by concurrent traffic. The resulting threshold may tighten
+        the fallback but never exceed it, so calibration running alongside a
+        blocking app cannot raise the threshold and blind later detection.
 
         Returns:
             The calibrated threshold in milliseconds.
@@ -206,14 +209,16 @@ class SentinelMonitor:
             lag_ms = (elapsed - interval_sec) * 1000.0
             samples.append(lag_ms)
 
-        # Use P75 as baseline to be robust against outliers
-        samples.sort()
-        p75_index = int(len(samples) * 0.75)
-        self._baseline_ms = samples[p75_index]
+        # Idle floor: the minimum lag is the least contaminated sample
+        self._baseline_ms = min(samples)
 
-        # Calculate threshold
-        self._threshold_ms = max(
-            self._baseline_ms * self._config.threshold_multiplier,
+        # Floor at the sampling interval (lag below it cannot be resolved),
+        # ceiling at the fallback (calibration may only ever lower it)
+        self._threshold_ms = min(
+            max(
+                self._baseline_ms * self._config.threshold_multiplier,
+                self._config.monitor_interval_ms,
+            ),
             self._config.fallback_threshold_ms,
         )
         self._calibrated = True

--- a/src/fastapi_loopguard/monitor.py
+++ b/src/fastapi_loopguard/monitor.py
@@ -276,7 +276,10 @@ class SentinelMonitor:
                 # Cumulative blocking detection
                 if self._config.cumulative_blocking_enabled:
                     now = loop.time()
-                    self._lag_history.append((now, lag_ms))
+                    # A sample consumed by the single-shot detection above is
+                    # not re-counted toward the cumulative window
+                    if not triggered:
+                        self._lag_history.append((now, lag_ms))
 
                     # Prune old samples
                     window_start = now - (self._config.cumulative_window_ms / 1000.0)
@@ -325,7 +328,7 @@ class SentinelMonitor:
 
         # Attribute to all active requests
         for ctx in active_contexts:
-            ctx.record_blocking(lag_ms)
+            ctx.record_blocking(lag_ms, cumulative=is_cumulative)
 
             if self._config.log_blocking_events:
                 logger.warning(

--- a/src/fastapi_loopguard/monitor.py
+++ b/src/fastapi_loopguard/monitor.py
@@ -70,6 +70,16 @@ class AdaptiveThreshold:
         """Number of samples currently in the window."""
         return len(self._samples)
 
+    def set_min_threshold(self, min_threshold_ms: float) -> None:
+        """Update the floor, e.g. after calibration tightens the threshold.
+
+        Until enough samples are collected, the current threshold follows the
+        floor so a stale initial value cannot overwrite a calibrated one.
+        """
+        self._min_threshold_ms = min_threshold_ms
+        if len(self._samples) < self._min_samples:
+            self._current_threshold_ms = min_threshold_ms
+
     def add_sample(self, lag_ms: float) -> None:
         """Add a new lag sample to the sliding window.
 
@@ -223,6 +233,11 @@ class SentinelMonitor:
         )
         self._calibrated = True
 
+        # Adaptive mode floors at the calibrated threshold, not the fallback;
+        # otherwise its first update would undo the calibration
+        if self._adaptive:
+            self._adaptive.set_min_threshold(self._threshold_ms)
+
         logger.info(
             "LoopGuard calibrated: baseline=%.2fms, threshold=%.2fms",
             self._baseline_ms,
@@ -248,6 +263,9 @@ class SentinelMonitor:
         loop = asyncio.get_running_loop()
         interval_sec = self._config.monitor_interval_ms / 1000.0
         adapt_interval_sec = self._config.adaptive_update_interval_ms / 1000.0
+        # Start the adaptive clock now; a 0.0 start would fire the first
+        # update on the very first iteration
+        self._last_adapt_time = loop.time()
 
         while self._running:
             try:

--- a/src/fastapi_loopguard/monitor.py
+++ b/src/fastapi_loopguard/monitor.py
@@ -259,7 +259,12 @@ class SentinelMonitor:
 
                 # Adaptive threshold processing
                 if self._adaptive:
-                    self._adaptive.add_sample(lag_ms)
+                    # Censor the window: only sub-threshold samples inform
+                    # the baseline. Admitting detected blocking makes the
+                    # threshold chase the blocking upward until detection
+                    # stops ("the worse the app gets, the less it reports").
+                    if lag_ms < self._threshold_ms:
+                        self._adaptive.add_sample(lag_ms)
                     now = loop.time()
                     if now - self._last_adapt_time >= adapt_interval_sec:
                         old_threshold = self._threshold_ms

--- a/tests/test_cumulative_blocking.py
+++ b/tests/test_cumulative_blocking.py
@@ -4,6 +4,11 @@ import time
 import pytest
 
 from fastapi_loopguard.config import LoopGuardConfig
+from fastapi_loopguard.context import (
+    RequestContext,
+    register_request,
+    unregister_request,
+)
 from fastapi_loopguard.monitor import SentinelMonitor
 
 
@@ -63,6 +68,57 @@ async def test_cumulative_blocking_detection() -> None:
 
     finally:
         await monitor.stop()
+
+
+@pytest.mark.asyncio
+async def test_single_block_reported_once() -> None:
+    # A single long block must produce exactly one event. The sample that
+    # fired the single-shot detection must not be re-counted by the
+    # cumulative window as a second event.
+    config = LoopGuardConfig(
+        monitor_interval_ms=10.0,
+        calibration_iterations=10,
+        fallback_threshold_ms=50.0,
+        cumulative_blocking_enabled=True,
+        cumulative_blocking_threshold_ms=200.0,
+        cumulative_window_ms=1000.0,
+        log_blocking_events=False,
+    )
+    detected: list[float] = []
+
+    def on_blocking(lag_ms: float, path: str | None, method: str | None) -> None:
+        detected.append(lag_ms)
+
+    monitor = SentinelMonitor(config, on_blocking=on_blocking)
+    ctx = RequestContext(request_id="req-1", path="/x", method="GET")
+
+    await monitor.start()
+    await asyncio.sleep(0.05)  # Let the monitor loop start ticking
+    register_request(ctx)
+    try:
+        time.sleep(0.3)  # ONE 300ms block, above both thresholds
+        await asyncio.sleep(0.1)  # Several monitor iterations observe the aftermath
+    finally:
+        unregister_request(ctx.request_id)
+        await monitor.stop()
+
+    assert len(detected) == 1, f"expected exactly one event, got {detected}"
+    assert 250.0 <= detected[0] <= 450.0
+    assert ctx.blocking_count == 1
+    assert 250.0 <= ctx.total_blocking_ms <= 450.0
+
+
+def test_cumulative_events_tracked_separately() -> None:
+    # Cumulative window sums must not be mixed into the individual-lag list;
+    # they carry different semantics (sum vs sample).
+    ctx = RequestContext(request_id="r1", path="/", method="GET")
+    ctx.record_blocking(30.0)
+    ctx.record_blocking(120.0, cumulative=True)
+
+    assert [lag for lag, _ in ctx.blocking_events] == [30.0]
+    assert [lag for lag, _ in ctx.cumulative_events] == [120.0]
+    assert ctx.blocking_count == 2
+    assert ctx.total_blocking_ms == 150.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_enforcement_mode.py
+++ b/tests/test_enforcement_mode.py
@@ -376,11 +376,11 @@ class TestStrictMode:
         assert response.headers.get("x-loopguard-enforcement") == "strict"
 
 
-class TestDevModeEscalation:
-    """Tests for dev_mode auto-escalation to strict mode."""
+class TestDevModeDoesNotEscalate:
+    """dev_mode only controls headers; it must never change the response status."""
 
-    async def test_dev_mode_escalates_warn_to_strict(self) -> None:
-        """Test that dev_mode=True escalates warn mode to strict."""
+    async def test_dev_mode_default_mode_returns_200_on_blocking(self) -> None:
+        """dev_mode with the default (warn) mode passes the response through."""
         app = FastAPI()
 
         @app.get("/blocking")
@@ -390,8 +390,7 @@ class TestDevModeEscalation:
             return {"status": "blocked"}
 
         config = LoopGuardConfig(
-            enforcement_mode="warn",  # Would normally be warn
-            dev_mode=True,  # But dev_mode escalates to strict
+            dev_mode=True,  # Must not escalate the default (warn) to strict
             monitor_interval_ms=2.0,
             fallback_threshold_ms=5.0,
             log_blocking_events=False,
@@ -406,8 +405,55 @@ class TestDevModeEscalation:
             await asyncio.sleep(0.1)
             response = await client.get("/blocking")
 
-        # Should get 503 because dev_mode escalates to strict
-        assert response.status_code == 503
+        # Response passes through with warn-mode diagnostics, no 503
+        assert response.status_code == 200
+        assert response.json() == {"status": "blocked"}
+        assert response.headers.get("x-blocking-detected") == "true"
+        assert response.headers.get("x-loopguard-warning") == "blocking-detected"
+
+    async def test_innocent_concurrent_requests_not_failed(self) -> None:
+        """Requests in flight during another request's blocking must not 503.
+
+        Blocking is attributed to ALL in-flight requests (the sentinel cannot
+        know the culprit), so a 503 on blocking_count > 0 punishes bystanders.
+        Only explicit strict mode may fail responses.
+        """
+        app = FastAPI()
+
+        @app.get("/block")
+        async def block_endpoint() -> dict[str, str]:
+            time.sleep(0.1)  # Sync block; returns without yielding after
+            return {"status": "blocked"}
+
+        @app.get("/fast")
+        async def fast_endpoint() -> dict[str, str]:
+            await asyncio.sleep(0.2)  # In flight while /block freezes the loop
+            return {"status": "fast"}
+
+        config = LoopGuardConfig(
+            dev_mode=True,
+            monitor_interval_ms=2.0,
+            fallback_threshold_ms=5.0,
+            log_blocking_events=False,
+        )
+        app.add_middleware(LoopGuardMiddleware, config=config)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+
+            async def blocker() -> int:
+                await asyncio.sleep(0.05)  # Let the fast requests register
+                return (await client.get("/block")).status_code
+
+            async def fast() -> int:
+                return (await client.get("/fast")).status_code
+
+            statuses = await asyncio.gather(*(fast() for _ in range(5)), blocker())
+
+        # Nobody gets a 503 outside explicit strict mode
+        assert statuses == [200] * 6
 
     async def test_dev_mode_respects_explicit_log_mode(self) -> None:
         """Test that dev_mode=True respects explicit log mode (no escalation)."""
@@ -442,70 +488,19 @@ class TestDevModeEscalation:
         # But should still have dev headers
         assert "x-request-id" in response.headers
 
-    async def test_dev_mode_escalates_default_to_strict(self) -> None:
-        """Test that dev_mode=True escalates default (warn) to strict."""
-        app = FastAPI()
-
-        @app.get("/blocking")
-        async def blocking_endpoint() -> dict[str, str]:
-            time.sleep(0.1)
-            await asyncio.sleep(0.02)
-            return {"status": "blocked"}
-
-        # Don't specify enforcement_mode - use default (warn)
-        config = LoopGuardConfig(
-            dev_mode=True,
-            monitor_interval_ms=2.0,
-            fallback_threshold_ms=5.0,
-            log_blocking_events=False,
-        )
-        app.add_middleware(LoopGuardMiddleware, config=config)
-
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            await client.get("/blocking")
-            await asyncio.sleep(0.1)
-            response = await client.get("/blocking")
-
-        # Should get 503 because dev_mode escalates default (warn) to strict
-        assert response.status_code == 503
-
 
 class TestEffectiveEnforcementMode:
     """Tests for _get_effective_enforcement_mode method."""
 
-    def test_effective_mode_without_dev_mode(self) -> None:
-        """Test effective mode returns configured mode when dev_mode=False."""
+    def test_effective_mode_is_configured_mode(self) -> None:
+        """Effective mode is always the configured mode, regardless of dev_mode."""
         app = FastAPI()
 
         for mode in ["log", "warn", "strict"]:
-            config = LoopGuardConfig(
-                enforcement_mode=mode,
-                dev_mode=False,
-            )
-            middleware = LoopGuardMiddleware(app, config=config)
-            assert middleware._get_effective_enforcement_mode() == mode
-
-    def test_effective_mode_with_dev_mode_escalates(self) -> None:
-        """Test effective mode escalates to strict when dev_mode=True."""
-        app = FastAPI()
-
-        # warn -> strict
-        config = LoopGuardConfig(enforcement_mode="warn", dev_mode=True)
-        middleware = LoopGuardMiddleware(app, config=config)
-        assert middleware._get_effective_enforcement_mode() == "strict"
-
-        # strict -> strict (no change)
-        config = LoopGuardConfig(enforcement_mode="strict", dev_mode=True)
-        middleware = LoopGuardMiddleware(app, config=config)
-        assert middleware._get_effective_enforcement_mode() == "strict"
-
-    def test_effective_mode_log_not_escalated(self) -> None:
-        """Test that log mode is not escalated even with dev_mode=True."""
-        app = FastAPI()
-
-        config = LoopGuardConfig(enforcement_mode="log", dev_mode=True)
-        middleware = LoopGuardMiddleware(app, config=config)
-        assert middleware._get_effective_enforcement_mode() == "log"
+            for dev_mode in [False, True]:
+                config = LoopGuardConfig(
+                    enforcement_mode=mode,
+                    dev_mode=dev_mode,
+                )
+                middleware = LoopGuardMiddleware(app, config=config)
+                assert middleware._get_effective_enforcement_mode() == mode

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -50,6 +50,15 @@ def clear_registry() -> None:
     get_registry().clear()
 
 
+def _live_loopguard_tasks() -> list[str]:
+    """Names of loopguard tasks still alive on the current loop."""
+    return sorted(
+        task.get_name()
+        for task in asyncio.all_tasks()
+        if task.get_name().startswith("loopguard") and not task.done()
+    )
+
+
 class TestLoopGuardMiddleware:
     """Tests for the middleware."""
 
@@ -335,6 +344,140 @@ class TestLifespanEvents:
         # Monitor should be stopped
         assert not middleware._started
         assert middleware._monitor is None
+
+    async def test_startup_failed_stops_monitor(self) -> None:
+        """lifespan.startup.failed must not leak a running monitor."""
+
+        async def failing_app(scope: Scope, receive: Receive, send: Send) -> None:
+            message = await receive()
+            assert message["type"] == "lifespan.startup"
+            await send({"type": "lifespan.startup.failed", "message": "db down"})
+
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=10,
+            log_blocking_events=False,
+        )
+        middleware = LoopGuardMiddleware(failing_app, config=config)
+
+        async def receive() -> Message:
+            return {"type": "lifespan.startup"}
+
+        async def send(message: Message) -> None:
+            pass
+
+        await middleware({"type": "lifespan"}, receive, send)
+
+        assert not middleware._started
+        assert middleware._monitor is None
+        assert _live_loopguard_tasks() == []
+
+    async def test_shutdown_failed_stops_monitor(self) -> None:
+        """lifespan.shutdown.failed must stop the monitor like shutdown.complete."""
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            await receive()  # lifespan.startup
+            await send({"type": "lifespan.startup.complete"})
+            await receive()  # lifespan.shutdown
+            await send({"type": "lifespan.shutdown.failed", "message": "cleanup"})
+
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=10,
+            log_blocking_events=False,
+        )
+        middleware = LoopGuardMiddleware(app, config=config)
+
+        messages = [{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}]
+
+        async def receive() -> Message:
+            return messages.pop(0)
+
+        async def send(message: Message) -> None:
+            pass
+
+        await middleware({"type": "lifespan"}, receive, send)
+
+        assert not middleware._started
+        assert middleware._monitor is None
+        assert _live_loopguard_tasks() == []
+
+    async def test_lazy_monitor_stops_when_idle(self) -> None:
+        """Without lifespan, the lazily started monitor must not leak tasks."""
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=10,
+            log_blocking_events=False,
+        )
+        middleware = LoopGuardMiddleware(app, config=config)
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: Message) -> None:
+            pass
+
+        scope = {"type": "http", "method": "GET", "path": "/x", "headers": []}
+        await middleware(scope, receive, send)
+
+        # Request finished, no requests in flight: nothing may keep running
+        assert not middleware._started
+        assert _live_loopguard_tasks() == []
+
+    async def test_lifespan_monitor_persists_across_requests(self) -> None:
+        """A lifespan-managed monitor must NOT stop between requests."""
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            if scope["type"] == "lifespan":
+                await receive()  # lifespan.startup
+                await send({"type": "lifespan.startup.complete"})
+                await asyncio.Event().wait()  # stay in lifespan until cancelled
+            else:
+                await send(
+                    {"type": "http.response.start", "status": 200, "headers": []}
+                )
+                await send({"type": "http.response.body", "body": b"ok"})
+
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=10,
+            log_blocking_events=False,
+        )
+        middleware = LoopGuardMiddleware(app, config=config)
+
+        async def lifespan_receive() -> Message:
+            return {"type": "lifespan.startup"}
+
+        async def send(message: Message) -> None:
+            pass
+
+        lifespan_task = asyncio.create_task(
+            middleware({"type": "lifespan"}, lifespan_receive, send)
+        )
+        await asyncio.sleep(0.05)
+        assert middleware._started
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        scope = {"type": "http", "method": "GET", "path": "/x", "headers": []}
+        try:
+            await middleware(scope, receive, send)
+
+            # Lifespan-managed monitor survives the request completing
+            assert middleware._started
+            assert "loopguard-monitor" in _live_loopguard_tasks()
+        finally:
+            lifespan_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await lifespan_task
+            if middleware._monitor:
+                await middleware._monitor.stop()
 
     async def test_middleware_without_lifespan_lazy_start(self) -> None:
         """Test that middleware starts lazily without lifespan events."""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -554,6 +554,39 @@ class TestSendWrapperConformance:
         )
         assert "http.response.trailers" in [m["type"] for m in sent]
 
+    _START_WITH_TRAILERS: list[Message] = [
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"trailer", b"x-checksum")],
+            "trailers": True,
+        },
+        {"type": "http.response.body", "body": b"data", "more_body": False},
+    ]
+
+    def _start_message(self, sent: list[Message]) -> Message:
+        return next(m for m in sent if m["type"] == "http.response.start")
+
+    async def test_warn_mode_preserves_start_message_keys(self) -> None:
+        """Rebuilding http.response.start must not drop keys like 'trailers'."""
+        config = LoopGuardConfig(enforcement_mode="warn", log_blocking_events=False)
+        sent = await self._drive(config, self._START_WITH_TRAILERS)
+        assert self._start_message(sent).get("trailers") is True
+
+    async def test_headers_mode_preserves_start_message_keys(self) -> None:
+        """The dev-mode headers wrapper must not drop keys like 'trailers'."""
+        config = LoopGuardConfig(
+            enforcement_mode="log", dev_mode=True, log_blocking_events=False
+        )
+        sent = await self._drive(config, self._START_WITH_TRAILERS)
+        assert self._start_message(sent).get("trailers") is True
+
+    async def test_strict_mode_preserves_start_message_keys(self) -> None:
+        """The strict wrapper (no blocking) must not drop keys like 'trailers'."""
+        config = LoopGuardConfig(enforcement_mode="strict", log_blocking_events=False)
+        sent = await self._drive(config, self._START_WITH_TRAILERS)
+        assert self._start_message(sent).get("trailers") is True
+
 
 class TestMiddlewareErrorHandling:
     """Tests for error handling in middleware."""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 import pytest
 from fastapi import FastAPI, Request
 from httpx import ASGITransport, AsyncClient
+from starlette.types import Message, Receive, Scope, Send
 from starlette.websockets import WebSocket
 
 from fastapi_loopguard import LoopGuardConfig, LoopGuardMiddleware
@@ -486,6 +487,72 @@ class TestWebSocketPassthrough:
 
         # Registry should be empty - WebSocket doesn't register
         assert get_registry().active_count() == 0
+
+
+class TestSendWrapperConformance:
+    """Send wrappers must forward unknown ASGI message types and preserve keys."""
+
+    @pytest.fixture(autouse=True)
+    def clear_registry(self) -> None:
+        """Clear the request registry before each test."""
+        get_registry().clear()
+
+    async def _drive(
+        self,
+        config: LoopGuardConfig,
+        messages: list[Message],
+    ) -> list[Message]:
+        """Send one request through the middleware, return what the server got."""
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            for message in messages:
+                await send(message)
+
+        middleware = LoopGuardMiddleware(app, config=config)
+        sent: list[Message] = []
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        scope = {"type": "http", "method": "GET", "path": "/x", "headers": []}
+        await middleware(scope, receive, send)
+        return sent
+
+    async def test_strict_mode_forwards_pathsend(self) -> None:
+        """FileResponse on pathsend-capable servers must not hang in strict mode."""
+        config = LoopGuardConfig(enforcement_mode="strict", log_blocking_events=False)
+        sent = await self._drive(
+            config,
+            [
+                {"type": "http.response.start", "status": 200, "headers": []},
+                {"type": "http.response.pathsend", "path": "/tmp/file.bin"},
+            ],
+        )
+        assert "http.response.pathsend" in [m["type"] for m in sent]
+
+    async def test_strict_mode_forwards_trailers_messages(self) -> None:
+        """http.response.trailers must pass through the strict-mode wrapper."""
+        config = LoopGuardConfig(enforcement_mode="strict", log_blocking_events=False)
+        sent = await self._drive(
+            config,
+            [
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                    "trailers": True,
+                },
+                {"type": "http.response.body", "body": b"data", "more_body": False},
+                {
+                    "type": "http.response.trailers",
+                    "headers": [(b"x-checksum", b"abc")],
+                },
+            ],
+        )
+        assert "http.response.trailers" in [m["type"] for m in sent]
 
 
 class TestMiddlewareErrorHandling:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -45,7 +45,10 @@ class TestSentinelMonitor:
         assert monitor.baseline_ms >= 0
         assert monitor.threshold_ms > 0
         assert threshold == monitor.threshold_ms
-        assert monitor.threshold_ms >= config.fallback_threshold_ms
+        # Calibration may tighten the threshold, never exceed the fallback,
+        # and never resolve below the sampling interval
+        assert monitor.threshold_ms <= config.fallback_threshold_ms
+        assert monitor.threshold_ms >= config.monitor_interval_ms
         assert monitor.is_calibrated
 
     async def test_start_and_stop(self, config: LoopGuardConfig) -> None:
@@ -557,8 +560,8 @@ class TestThresholdEdgeCases:
 
         await monitor.stop()
 
-    async def test_threshold_above_fallback_after_calibration(self) -> None:
-        """Test threshold is at least fallback after calibration."""
+    async def test_threshold_never_above_fallback_after_calibration(self) -> None:
+        """Calibration must never raise the threshold above the fallback."""
         config = LoopGuardConfig(
             monitor_interval_ms=5.0,
             calibration_iterations=10,
@@ -570,9 +573,35 @@ class TestThresholdEdgeCases:
 
         await monitor.calibrate()
 
-        # Threshold should be at least fallback
-        assert monitor.threshold_ms >= config.fallback_threshold_ms
+        assert monitor.threshold_ms <= config.fallback_threshold_ms
+        assert monitor.threshold_ms >= config.monitor_interval_ms
         assert monitor.is_calibrated
+
+    async def test_contaminated_calibration_never_raises_threshold(self) -> None:
+        """Calibration under live blocking must not raise the threshold.
+
+        A percentile of contaminated samples let a blocking app calibrate
+        itself blind: the threshold went far above the fallback and real
+        blocking was never detected again.
+        """
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=10,
+            threshold_multiplier=3.0,
+            fallback_threshold_ms=20.0,
+            log_blocking_events=False,
+        )
+        monitor = SentinelMonitor(config)
+
+        calibration = asyncio.create_task(monitor.calibrate())
+        # App blocks ~20ms per request for the whole calibration window
+        while not calibration.done():
+            time.sleep(0.02)
+            await asyncio.sleep(0.001)
+        await calibration
+
+        assert monitor.is_calibrated
+        assert monitor.threshold_ms <= config.fallback_threshold_ms
 
 
 class TestCalibrationEdgeCases:
@@ -629,27 +658,23 @@ class TestCalibrationEdgeCases:
 
         await monitor.stop()
 
-    async def test_calibration_calculates_p75(self) -> None:
-        """Test that calibration correctly calculates P75 percentile."""
+    async def test_calibration_fallback_ceiling_beats_interval_floor(self) -> None:
+        """The fallback ceiling is absolute, even below the interval floor."""
         config = LoopGuardConfig(
             monitor_interval_ms=1.0,  # Very fast
             calibration_iterations=20,
             threshold_multiplier=5.0,
-            fallback_threshold_ms=0.1,
+            fallback_threshold_ms=0.1,  # Below the interval floor
             log_blocking_events=False,
         )
         monitor = SentinelMonitor(config)
 
         await monitor.calibrate()
 
-        # Baseline should be set (P75 of samples)
+        # Baseline is the idle floor (min sample), never negative
         assert monitor.baseline_ms >= 0
-        # Threshold should be baseline * multiplier (or fallback if higher)
-        expected_min = max(
-            monitor.baseline_ms * config.threshold_multiplier,
-            config.fallback_threshold_ms,
-        )
-        assert monitor.threshold_ms >= expected_min - 0.001  # Small tolerance
+        # The fallback remains a hard ceiling
+        assert monitor.threshold_ms == config.fallback_threshold_ms
 
 
 class TestTaskCancellation:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -383,6 +383,44 @@ class TestSentinelMonitorAdaptive:
         assert monitor._adaptive is not None
         assert monitor._adaptive.sample_count > 0
 
+    async def test_adaptive_threshold_not_fed_by_detected_blocking(self) -> None:
+        """Sustained blocking must not raise the adaptive threshold.
+
+        Detected-blocking samples fed the window, so under sustained blocking
+        the threshold chased the blocking upward and detections stopped.
+        """
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=1000,  # Never completes during this test
+            threshold_multiplier=3.0,
+            fallback_threshold_ms=20.0,
+            adaptive_threshold=True,
+            adaptive_window_size=100,
+            adaptive_min_samples=10,
+            adaptive_update_interval_ms=50.0,
+            cumulative_blocking_enabled=False,
+            log_blocking_events=False,
+        )
+        events: list[float] = []
+
+        def on_blocking(lag_ms: float, path: str | None, method: str | None) -> None:
+            events.append(lag_ms)
+
+        monitor = SentinelMonitor(config, on_blocking=on_blocking)
+        await monitor.start_with_background_calibration()
+        await asyncio.sleep(0.05)  # Let the monitor loop start ticking
+
+        for _ in range(30):
+            time.sleep(0.03)  # 30ms block, above the 20ms fallback threshold
+            await asyncio.sleep(0.002)
+
+        await monitor.stop()
+
+        # The threshold must not have chased the blocking upward
+        assert monitor.threshold_ms == config.fallback_threshold_ms
+        # Detection must keep firing for the whole run, not fade out
+        assert len(events) >= 25
+
 
 class TestMonitorIdempotency:
     """Tests for idempotent start/stop operations."""

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -383,6 +383,54 @@ class TestSentinelMonitorAdaptive:
         assert monitor._adaptive is not None
         assert monitor._adaptive.sample_count > 0
 
+    async def test_adaptive_does_not_discard_calibrated_threshold(self) -> None:
+        """Adaptive mode must not undo a calibration-tightened threshold.
+
+        The adaptive floor was fixed at fallback_threshold_ms and its first
+        update fired immediately, so a calibrated threshold below the
+        fallback was overwritten back to the fallback on the first tick.
+        """
+        config = LoopGuardConfig(
+            monitor_interval_ms=5.0,
+            calibration_iterations=10,
+            threshold_multiplier=3.0,
+            fallback_threshold_ms=20.0,
+            adaptive_threshold=True,
+            adaptive_window_size=100,
+            adaptive_min_samples=100,  # Not reached during this test
+            adaptive_update_interval_ms=10.0,  # Updates fire often
+            cumulative_blocking_enabled=False,
+            log_blocking_events=False,
+        )
+        monitor = SentinelMonitor(config)
+
+        await monitor.start()  # Calibrates idle: threshold below fallback
+        calibrated = monitor.threshold_ms
+        assert calibrated < config.fallback_threshold_ms
+
+        await asyncio.sleep(0.1)  # Several adaptive update ticks pass
+        await monitor.stop()
+
+        assert monitor.threshold_ms == calibrated
+
+    def test_set_min_threshold_lowers_floor(self) -> None:
+        """A lowered floor takes effect immediately and bounds recalculation."""
+        adaptive = AdaptiveThreshold(
+            window_size=100,
+            percentile=0.95,
+            multiplier=5.0,
+            min_threshold_ms=50.0,
+            min_samples=10,
+        )
+
+        adaptive.set_min_threshold(10.0)
+        assert adaptive.current_threshold_ms == 10.0
+
+        for _ in range(20):
+            adaptive.add_sample(1.0)
+        # P95 of 1.0 samples x 5 = 5.0, floored at the new 10.0
+        assert adaptive.recalculate() == 10.0
+
     async def test_adaptive_threshold_not_fed_by_detected_blocking(self) -> None:
         """Sustained blocking must not raise the adaptive threshold.
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,42 @@
+"""Regression tests for release metadata.
+
+Covers: __version__ drifting from pyproject.toml, and the 503 error page
+linking to the wrong GitHub repository.
+"""
+
+import importlib.metadata
+import pathlib
+import tomllib
+
+from starlette.types import Receive, Scope, Send
+
+import fastapi_loopguard
+from fastapi_loopguard import LoopGuardMiddleware
+from fastapi_loopguard.context import RequestContext
+
+
+async def _dummy_app(scope: Scope, receive: Receive, send: Send) -> None:
+    """Minimal ASGI app for constructing the middleware."""
+
+
+def test_version_matches_installed_metadata() -> None:
+    """__version__ must be derived from the installed package metadata."""
+    assert fastapi_loopguard.__version__ == importlib.metadata.version(
+        "fastapi-loopguard"
+    )
+
+
+def test_version_matches_pyproject() -> None:
+    """__version__ must agree with pyproject.toml (no hand-written drift)."""
+    pyproject = pathlib.Path(__file__).resolve().parent.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    assert fastapi_loopguard.__version__ == data["project"]["version"]
+
+
+def test_error_page_links_to_real_repo() -> None:
+    """The 503 page must link to the repository that actually ships this code."""
+    middleware = LoopGuardMiddleware(_dummy_app)
+    ctx = RequestContext(request_id="abc12345", path="/x", method="GET")
+    html = middleware._generate_error_html(ctx)
+    assert "https://github.com/parhamdavari/fastapi-loopguard" in html
+    assert "pyhub-kr" not in html


### PR DESCRIPTION
Nine correctness fixes ahead of the 0.5.0 release. Every defect was reproduced with a standalone script before fixing, and every fix landed with a regression test that failed on main. See CHANGELOG.md for the symptom-level summary and FINDINGS.md for issues noticed but deliberately deferred.

## Fixes

- **dev_mode no longer 503s innocent requests.** Blocking is attributed to all in-flight requests, so the silent dev_mode->strict escalation failed every concurrent bystander with 503 while the actual culprit returned 200. dev_mode is now headers-only; 503 requires explicit `enforcement_mode="strict"`. Docs no longer claim per-endpoint attribution.
- **One blocking event is reported once.** A 300ms block produced two events summing to ~600ms (single-shot + cumulative re-count). Single-shot samples are pruned from the cumulative window and window sums live in a separate `cumulative_events` list.
- **Calibration cannot be poisoned by live traffic.** Background calibration under blocking startup traffic raised the threshold to ~8x the fallback and blinded detection. Baseline is now the idle floor (min sample), clamped to `[monitor_interval_ms, fallback_threshold_ms]`.
- **The adaptive threshold no longer chases sustained blocking.** Only sub-threshold samples are admitted to the adaptive window (120x70ms blocks: 9 detections before, 119 after).
- **Adaptive mode no longer discards the calibrated threshold.** Its floor was pinned at the fallback and its first update fired immediately, snapping a calibrated 10ms threshold back to 50ms on the first tick.
- **Unknown ASGI messages pass through the strict-mode wrapper.** `http.response.pathsend` (Starlette FileResponse on Hypercorn/Granian) and `http.response.trailers` no longer hang responses.
- **`http.response.start` keys survive header injection** (notably `"trailers": True`).
- **No leaked monitor tasks.** `lifespan.startup.failed` / `lifespan.shutdown.failed` now stop the monitor, and lazily started monitors (no lifespan, e.g. `httpx.ASGITransport` tests) stop when the last in-flight request finishes.
- **Version metadata fixed.** `__version__` is derived from package metadata (was 0.3.0 vs pyproject 0.4.1); the 503 page links to the real repo; version bumped to 0.5.0.

## Verification

- `pytest`: 171 passed, 1 skipped (prometheus extra not installed)
- `mypy src/` strict: clean
- `ruff check` + `ruff format --check`: clean
- `coverage`: 88% (gate: 80%)
- All 8 Phase-1 repro scripts re-run against the fix and show corrected behavior