### PR TITLE
Close the audit's test gaps; plugin and logging hygiene

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "httpx>=0.27.0",
     "fastapi>=0.110.0",
+    # Without this, tests/test_metrics.py importorskip-skips silently and
+    # metrics.py sits at 0% coverage in CI
+    "prometheus-client>=0.19.0",
     "mypy>=1.8.0",
     "ruff>=0.3.0",
     "coverage>=7.4.0",

--- a/src/fastapi_loopguard/logging.py
+++ b/src/fastapi_loopguard/logging.py
@@ -35,6 +35,12 @@ class StructuredFormatter(logging.Formatter):
         if hasattr(record, "blocking_count"):
             log_data["blocking_count"] = record.blocking_count
 
+        # Preserve tracebacks: the monitor's failure paths use
+        # logger.exception, and dropping exc_info would discard the only
+        # diagnostics for a failed calibration or a crashed monitor loop
+        if record.exc_info:
+            log_data["exc_info"] = self.formatException(record.exc_info)
+
         return json.dumps(log_data)
 
 
@@ -45,12 +51,22 @@ def configure_logging(
 ) -> None:
     """Configure logging for LoopGuard.
 
+    Idempotent: calling it again replaces the handler it installed earlier
+    instead of stacking a duplicate, and propagation to the root logger is
+    disabled so an app with its own root handler does not log every event
+    twice.
+
     Args:
         level: The logging level (default INFO).
         structured: If True, use JSON formatting.
         stream: Output stream (default stderr).
     """
+    for existing in list(logger.handlers):
+        if getattr(existing, "_loopguard_handler", False):
+            logger.removeHandler(existing)
+
     handler = logging.StreamHandler(stream or sys.stderr)
+    handler._loopguard_handler = True  # type: ignore[attr-defined]
 
     if structured:
         handler.setFormatter(StructuredFormatter())
@@ -61,6 +77,7 @@ def configure_logging(
 
     logger.addHandler(handler)
     logger.setLevel(level)
+    logger.propagate = False
 
 
 def log_blocking_event(

--- a/src/fastapi_loopguard/pytest_plugin.py
+++ b/src/fastapi_loopguard/pytest_plugin.py
@@ -17,8 +17,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import contextlib
-from collections.abc import Generator
+import inspect
 from typing import Any
 
 import pytest
@@ -60,12 +59,22 @@ class BlockingDetector:
         self._task = asyncio.create_task(self._monitor())
 
     async def stop(self) -> None:
-        """Stop the blocking detector."""
+        """Stop the blocking detector.
+
+        Runs inside test finally blocks, so it must not swallow a
+        cancellation aimed at the test itself (e.g. a timeout plugin).
+        """
         self._running = False
-        if self._task:
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._task
+        task = self._task
+        self._task = None
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
 
     async def _monitor(self) -> None:
         """Monitor for blocking."""
@@ -82,18 +91,6 @@ class BlockingDetector:
                 self.blocking_events.append(lag_ms)
 
 
-@pytest.fixture
-def loopguard_detector(
-    request: pytest.FixtureRequest,
-) -> Generator[BlockingDetector, None, None]:
-    """Fixture that provides a blocking detector for tests."""
-    threshold_str = request.config.getini("loopguard_threshold_ms")
-    threshold = float(threshold_str) if threshold_str else 50.0
-
-    detector = BlockingDetector(threshold_ms=threshold)
-    yield detector
-
-
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_call(item: pytest.Item) -> None:
     """Check for blocking after test execution."""
@@ -108,28 +105,38 @@ def pytest_runtest_call(item: pytest.Item) -> None:
     # Store the original test function
     original_func = item.obj
 
-    if asyncio.iscoroutinefunction(original_func):
-        # Wrap async test with blocking detection
-        async def wrapped(*args: Any, **kwargs: Any) -> Any:
-            threshold_str = item.config.getini("loopguard_threshold_ms")
-            threshold = float(threshold_str) if threshold_str else 50.0
+    if not inspect.iscoroutinefunction(original_func):
+        # A sync test never runs on the event loop; silently passing would
+        # let the author believe blocking was checked
+        item.warn(
+            pytest.PytestWarning(
+                f"@pytest.mark.{MARKER_NAME} has no effect on synchronous "
+                f"test {item.nodeid}: there is no event loop to monitor"
+            )
+        )
+        return
 
-            detector = BlockingDetector(threshold_ms=threshold)
-            await detector.start()
+    # Wrap async test with blocking detection
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        threshold_str = item.config.getini("loopguard_threshold_ms")
+        threshold = float(threshold_str) if threshold_str else 50.0
 
-            try:
-                result = await original_func(*args, **kwargs)
-            finally:
-                await detector.stop()
+        detector = BlockingDetector(threshold_ms=threshold)
+        await detector.start()
 
-            if detector.blocking_events:
-                max_lag = max(detector.blocking_events)
-                pytest.fail(
-                    f"Event loop blocking detected! "
-                    f"{len(detector.blocking_events)} blocking event(s), "
-                    f"max lag: {max_lag:.2f}ms (threshold: {threshold}ms)"
-                )
+        try:
+            result = await original_func(*args, **kwargs)
+        finally:
+            await detector.stop()
 
-            return result
+        if detector.blocking_events:
+            max_lag = max(detector.blocking_events)
+            pytest.fail(
+                f"Event loop blocking detected! "
+                f"{len(detector.blocking_events)} blocking event(s), "
+                f"max lag: {max_lag:.2f}ms (threshold: {threshold}ms)"
+            )
 
-        item.obj = wrapped
+        return result
+
+    item.obj = wrapped

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,3 +158,27 @@ class TestCrossFieldValidation:
         """A bare string would silently become a substring match."""
         with pytest.raises(ValueError, match="exclude_paths"):
             LoopGuardConfig(exclude_paths="/health")  # type: ignore[arg-type]
+
+
+class TestRemainingValidationBranches:
+    """The validation branches that had no dedicated test."""
+
+    def test_adaptive_min_samples_above_window_rejected(self) -> None:
+        with pytest.raises(ValueError, match="adaptive_min_samples"):
+            LoopGuardConfig(adaptive_window_size=100, adaptive_min_samples=200)
+
+    def test_cumulative_threshold_nonpositive_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cumulative_blocking_threshold_ms"):
+            LoopGuardConfig(cumulative_blocking_threshold_ms=0)
+
+    def test_cumulative_window_nonpositive_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cumulative_window_ms"):
+            LoopGuardConfig(cumulative_window_ms=-1)
+
+    def test_cumulative_window_below_interval_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cumulative_window_ms"):
+            LoopGuardConfig(
+                monitor_interval_ms=50.0,
+                fallback_threshold_ms=50.0,
+                cumulative_window_ms=20.0,
+            )

--- a/tests/test_cumulative_blocking.py
+++ b/tests/test_cumulative_blocking.py
@@ -165,3 +165,64 @@ async def test_cumulative_blocking_can_be_disabled() -> None:
         )
     finally:
         await monitor.stop()
+
+
+def test_window_pruning_by_age() -> None:
+    """Samples older than the window drop out and stop contributing."""
+    config = LoopGuardConfig(
+        monitor_interval_ms=10.0,
+        fallback_threshold_ms=50.0,
+        cumulative_blocking_threshold_ms=100.0,
+        cumulative_window_ms=200.0,  # short window
+        log_blocking_events=False,
+    )
+    detected: list[float] = []
+
+    def on_blocking(lag_ms: float, path: str | None, method: str | None) -> None:
+        detected.append(lag_ms)
+
+    monitor = SentinelMonitor(config, on_blocking=on_blocking)
+
+    # 90ms of excess accumulated at t=0.00-0.08 - just under the threshold
+    for i in range(9):
+        monitor._check_cumulative(now=i * 0.01, lag_ms=10.0, triggered=False)
+    assert detected == []
+    assert len(monitor._lag_history) == 9
+
+    # After an idle gap longer than the window, old samples are pruned:
+    # this tick alone cannot fire even though 90 + 10 would have
+    monitor._check_cumulative(now=1.0, lag_ms=10.0, triggered=False)
+    assert detected == []
+    assert len(monitor._lag_history) == 1
+
+
+@pytest.mark.asyncio
+async def test_cumulative_attribution_end_to_end() -> None:
+    """Sub-threshold repeated blocking attributes cumulatively to contexts."""
+    config = LoopGuardConfig(
+        monitor_interval_ms=10.0,
+        fallback_threshold_ms=50.0,  # single-shot stays quiet
+        cumulative_blocking_threshold_ms=60.0,
+        cumulative_window_ms=1000.0,
+        log_blocking_events=False,
+    )
+    monitor = SentinelMonitor(config)
+    await monitor.start_with_background_calibration()
+    await asyncio.sleep(0.15)
+
+    ctx = RequestContext(request_id="cumul-e2e", path="/api/report", method="GET")
+    register_request(ctx)
+
+    try:
+        # Repeated sub-threshold blocking: each ~25ms block stays under the
+        # 50ms single-shot threshold, but the window sums past 60ms
+        for _ in range(6):
+            time.sleep(0.025)
+            await asyncio.sleep(0.02)
+    finally:
+        unregister_request(ctx.request_id)
+        await monitor.stop()
+
+    assert len(ctx.cumulative_events) >= 1
+    assert ctx.blocking_count >= 1
+    assert ctx.total_blocking_ms > 0

--- a/tests/test_enforcement_mode.py
+++ b/tests/test_enforcement_mode.py
@@ -587,3 +587,126 @@ class TestStrictModeStreaming:
             await middleware(scope, receive, send)
 
         assert sent == []  # neither the app's 200 nor a LoopGuard 503
+
+
+class TestStrictModeHeaders:
+    """Full header contract of the strict 503 and the clean pass-through."""
+
+    def _blocking_app(self) -> FastAPI:
+        app = FastAPI()
+
+        @app.get("/blocking")
+        async def blocking_endpoint() -> dict[str, str]:
+            time.sleep(0.1)
+            await asyncio.sleep(0.02)
+            return {"status": "blocked"}
+
+        @app.get("/fast")
+        async def fast_endpoint() -> dict[str, str]:
+            await asyncio.sleep(0.001)
+            return {"status": "fast"}
+
+        config = LoopGuardConfig(
+            enforcement_mode="strict",
+            monitor_interval_ms=2.0,
+            fallback_threshold_ms=5.0,
+            log_blocking_events=False,
+        )
+        app.add_middleware(LoopGuardMiddleware, config=config)
+        return app
+
+    async def test_503_carries_full_strict_header_set(self) -> None:
+        app = self._blocking_app()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            await client.get("/fast")
+            await asyncio.sleep(0.05)
+            response = await client.get("/blocking")
+
+        assert response.status_code == 503
+        assert response.headers.get("x-loopguard-enforcement") == "strict"
+        assert "x-request-id" in response.headers
+        assert int(response.headers["x-blocking-count"]) >= 1
+        assert float(response.headers["x-blocking-total-ms"]) > 0
+        # The strict 503 header set omits x-blocking-detected by contract
+        assert "x-blocking-detected" not in response.headers
+        assert int(response.headers["content-length"]) == len(response.content)
+
+    async def test_clean_strict_response_carries_diagnostic_headers(self) -> None:
+        app = self._blocking_app()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.get("/fast")
+
+        assert response.status_code == 200
+        assert response.headers.get("x-blocking-detected") == "false"
+        assert response.headers.get("x-blocking-count") == "0"
+        assert "x-loopguard-enforcement" not in response.headers
+
+    async def test_missing_accept_header_gets_json(self) -> None:
+        app = self._blocking_app()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            await client.get("/fast")
+            await asyncio.sleep(0.05)
+            response = await client.get("/blocking", headers={"Accept": ""})
+
+        assert response.status_code == 503
+        assert response.headers["content-type"].startswith("application/json")
+
+
+class TestStrictModeBystanders:
+    """Documents FINDINGS: strict mode 503s every in-flight request.
+
+    The sentinel measures lag, not call stacks, so it cannot name the
+    culprit; under concurrency, strict mode punishes bystanders. This is
+    the documented reason strict is opt-in (invariant 6).
+    """
+
+    async def test_concurrent_bystander_also_gets_503(self) -> None:
+        app = FastAPI()
+
+        @app.get("/blocking")
+        async def blocking_endpoint() -> dict[str, str]:
+            await asyncio.sleep(0.02)  # let the bystander register first
+            time.sleep(0.1)
+            await asyncio.sleep(0.02)
+            return {"status": "blocked"}
+
+        @app.get("/innocent")
+        async def innocent_endpoint() -> dict[str, str]:
+            await asyncio.sleep(0.2)  # in flight during the stall
+            return {"status": "innocent"}
+
+        config = LoopGuardConfig(
+            enforcement_mode="strict",
+            monitor_interval_ms=2.0,
+            fallback_threshold_ms=5.0,
+            log_blocking_events=False,
+        )
+        app.add_middleware(LoopGuardMiddleware, config=config)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            await client.get("/innocent")  # warmup: start monitor
+            await asyncio.sleep(0.05)
+
+            culprit, bystander = await asyncio.gather(
+                client.get("/blocking"),
+                client.get("/innocent"),
+            )
+
+        assert culprit.status_code == 503
+        # The bystander was in flight during the stall, so it is 503'd too
+        assert bystander.status_code == 503

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -117,9 +117,15 @@ class TestConfigureLogging:
 
     @pytest.fixture(autouse=True)
     def cleanup_handlers(self) -> None:
-        """Remove handlers after each test."""
+        """Restore logger state after each test.
+
+        configure_logging disables propagation; leaving that in place would
+        break caplog-based tests elsewhere in the suite.
+        """
         yield
         logger.handlers.clear()
+        logger.propagate = True
+        logger.setLevel(logging.NOTSET)
 
     def test_configure_with_defaults(self) -> None:
         """Test configuration with default values."""
@@ -240,3 +246,60 @@ class TestLogBlockingEvent:
         data = json.loads(output.strip())
 
         assert data["level"] == "WARNING"
+
+
+class TestConfigureLoggingIdempotence:
+    """configure_logging must not stack handlers or double-log."""
+
+    @pytest.fixture(autouse=True)
+    def cleanup_handlers(self) -> None:
+        """Restore logger state after each test."""
+        yield
+        logger.handlers.clear()
+        logger.propagate = True
+        logger.setLevel(logging.NOTSET)
+
+    def test_second_call_replaces_handler(self) -> None:
+        first = StringIO()
+        second = StringIO()
+
+        configure_logging(stream=first)
+        configure_logging(stream=second)
+
+        assert len(logger.handlers) == 1
+
+        logger.warning("once")
+        assert "once" not in first.getvalue()
+        assert second.getvalue().count("once") == 1
+
+    def test_propagation_disabled(self) -> None:
+        """A root handler must not receive our events a second time."""
+        configure_logging(stream=StringIO())
+        assert logger.propagate is False
+
+
+class TestStructuredFormatterExcInfo:
+    """Tracebacks must survive structured formatting."""
+
+    def test_exc_info_preserved(self) -> None:
+        formatter = StructuredFormatter()
+        try:
+            raise ValueError("calibration exploded")
+        except ValueError:
+            import sys
+
+            record = logging.LogRecord(
+                name="fastapi_loopguard",
+                level=logging.ERROR,
+                pathname="",
+                lineno=0,
+                msg="LoopGuard calibration failed",
+                args=(),
+                exc_info=sys.exc_info(),
+            )
+
+        data = json.loads(formatter.format(record))
+
+        assert "exc_info" in data
+        assert "ValueError: calibration exploded" in data["exc_info"]
+        assert "Traceback" in data["exc_info"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -954,3 +954,299 @@ class TestLifespanExceptionCleanup:
         assert middleware._started is False
         assert middleware._monitor is None
         assert _live_loopguard_tasks() == []
+
+
+class TestResponseShapeConformance:
+    """Response shapes beyond one start + one terminal body."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_registry(self) -> None:
+        get_registry().clear()
+
+    async def _drive_messages(
+        self,
+        config: LoopGuardConfig,
+        messages: list[Message],
+        path: str = "/x",
+    ) -> list[Message]:
+        """Send one request through the middleware, return what the server got."""
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            for message in messages:
+                await send(message)
+
+        middleware = LoopGuardMiddleware(app, config=config)
+        sent: list[Message] = []
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        scope: Scope = {"type": "http", "method": "GET", "path": path, "headers": []}
+        await middleware(scope, receive, send)
+        return sent
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            LoopGuardConfig(log_blocking_events=False),  # warn (default)
+            LoopGuardConfig(
+                enforcement_mode="log", dev_mode=True, log_blocking_events=False
+            ),  # dev headers
+            LoopGuardConfig(
+                enforcement_mode="strict", log_blocking_events=False
+            ),  # strict clean path
+        ],
+        ids=["warn", "dev-headers", "strict"],
+    )
+    async def test_streaming_bodies_pass_through_every_wrapper(
+        self, config: LoopGuardConfig
+    ) -> None:
+        """Multiple body chunks with more_body survive all three wrappers."""
+        chunks = [
+            {"type": "http.response.body", "body": b"a", "more_body": True},
+            {"type": "http.response.body", "body": b"b", "more_body": True},
+            {"type": "http.response.body", "body": b"c", "more_body": False},
+        ]
+        sent = await self._drive_messages(
+            config,
+            [{"type": "http.response.start", "status": 200, "headers": []}, *chunks],
+        )
+
+        starts = [m for m in sent if m["type"] == "http.response.start"]
+        bodies = [m for m in sent if m["type"] == "http.response.body"]
+        assert len(starts) == 1  # headers injected exactly once
+        assert [m["body"] for m in bodies] == [b"a", b"b", b"c"]
+        header_names = [name for name, _ in starts[0]["headers"]]
+        assert b"x-request-id" in header_names
+
+    async def test_no_body_204_response(self) -> None:
+        """A 204 with an empty terminal body passes untouched."""
+        config = LoopGuardConfig(dev_mode=True, log_blocking_events=False)
+        sent = await self._drive_messages(
+            config,
+            [
+                {"type": "http.response.start", "status": 204, "headers": []},
+                {"type": "http.response.body", "body": b"", "more_body": False},
+            ],
+        )
+
+        assert sent[0]["status"] == 204
+        assert dict(sent[0]["headers"])[b"x-blocking-detected"] == b"false"
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            LoopGuardConfig(log_blocking_events=False),
+            LoopGuardConfig(
+                enforcement_mode="log", dev_mode=True, log_blocking_events=False
+            ),
+        ],
+        ids=["warn", "dev-headers"],
+    )
+    async def test_pathsend_and_trailers_forwarded(
+        self, config: LoopGuardConfig
+    ) -> None:
+        """Extension messages pass through the warn and dev-header wrappers."""
+        sent = await self._drive_messages(
+            config,
+            [
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                    "trailers": True,
+                },
+                {"type": "http.response.pathsend", "path": "/tmp/file.bin"},
+                {"type": "http.response.trailers", "headers": [(b"x-t", b"1")]},
+            ],
+        )
+
+        types = [m["type"] for m in sent]
+        assert "http.response.pathsend" in types
+        assert "http.response.trailers" in types
+        assert sent[0].get("trailers") is True  # start-message key preserved
+
+    async def test_app_exception_propagates_before_response_start(self) -> None:
+        """An exception before any send propagates; nothing reaches the client."""
+        config = LoopGuardConfig(log_blocking_events=False)
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            raise RuntimeError("pre-start explosion")
+
+        middleware = LoopGuardMiddleware(app, config=config)
+        sent: list[Message] = []
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        scope: Scope = {"type": "http", "method": "GET", "path": "/x", "headers": []}
+        with pytest.raises(RuntimeError, match="pre-start explosion"):
+            await middleware(scope, receive, send)
+
+        assert sent == []
+        assert get_registry().active_count() == 0  # context unregistered
+
+
+class TestLifespanEdgeCases:
+    """Repeated and out-of-order lifespan events."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_registry(self) -> None:
+        get_registry().clear()
+
+    async def _run_lifespan(
+        self,
+        middleware: LoopGuardMiddleware,
+        incoming: list[Message],
+    ) -> list[Message]:
+        """Drive one lifespan connection: app echoes a terminal per message."""
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            for _ in range(len(incoming)):
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+
+        middleware.app = app
+        queue = list(incoming)
+        sent: list[Message] = []
+
+        async def receive() -> Message:
+            return queue.pop(0)
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        await middleware({"type": "lifespan"}, receive, send)
+        return sent
+
+    async def test_double_startup_starts_one_monitor(self) -> None:
+        config = LoopGuardConfig(log_blocking_events=False)
+        middleware = LoopGuardMiddleware(lambda: None, config=config)  # replaced
+
+        await self._run_lifespan(
+            middleware,
+            [{"type": "lifespan.startup"}, {"type": "lifespan.startup"}],
+        )
+        first_monitor = middleware._monitor
+
+        assert middleware._started is True
+        assert first_monitor is not None
+        await middleware._stop_monitor()
+
+    async def test_startup_after_shutdown_restarts_monitor(self) -> None:
+        config = LoopGuardConfig(log_blocking_events=False)
+        middleware = LoopGuardMiddleware(lambda: None, config=config)
+
+        await self._run_lifespan(
+            middleware,
+            [{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}],
+        )
+        assert middleware._started is False
+        assert _live_loopguard_tasks() == []
+
+        await self._run_lifespan(middleware, [{"type": "lifespan.startup"}])
+        assert middleware._started is True
+        assert middleware._monitor is not None
+
+        await middleware._stop_monitor()
+
+    async def test_disabled_middleware_lifespan_starts_nothing(self) -> None:
+        config = LoopGuardConfig(enabled=False, log_blocking_events=False)
+        middleware = LoopGuardMiddleware(lambda: None, config=config)
+
+        await self._run_lifespan(
+            middleware,
+            [{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}],
+        )
+
+        assert middleware._started is False
+        assert middleware._monitor is None
+        assert _live_loopguard_tasks() == []
+
+
+class TestExcludePathSemantics:
+    """exclude_paths is an exact match on the raw scope path."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_registry(self) -> None:
+        get_registry().clear()
+
+    async def _request_monitored(self, config: LoopGuardConfig, path: str) -> bool:
+        """True if the request registered a context (i.e. was monitored)."""
+        registered: list[int] = []
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            registered.append(get_registry().active_count())
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = LoopGuardMiddleware(app, config=config)
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: Message) -> None:
+            pass
+
+        scope: Scope = {"type": "http", "method": "GET", "path": path, "headers": []}
+        await middleware(scope, receive, send)
+        return registered[0] > 0
+
+    async def test_custom_exclude_paths(self) -> None:
+        config = LoopGuardConfig(
+            exclude_paths=frozenset({"/internal/ping"}), log_blocking_events=False
+        )
+        assert await self._request_monitored(config, "/internal/ping") is False
+        assert await self._request_monitored(config, "/api/users") is True
+
+    async def test_exclusion_is_exact_not_prefix(self) -> None:
+        """Documents current semantics: /health/live is NOT excluded by /health."""
+        config = LoopGuardConfig(log_blocking_events=False)
+        assert await self._request_monitored(config, "/health") is False
+        assert await self._request_monitored(config, "/health/live") is True
+
+
+class TestScopeStatePreserved:
+    """A pre-populated scope state dict must be extended, not replaced."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_registry(self) -> None:
+        get_registry().clear()
+
+    async def test_existing_state_keys_survive(self) -> None:
+        config = LoopGuardConfig(log_blocking_events=False)
+        seen: dict[str, object] = {}
+
+        async def app(scope: Scope, receive: Receive, send: Send) -> None:
+            seen.update(scope["state"])
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = LoopGuardMiddleware(app, config=config)
+
+        async def receive() -> Message:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: Message) -> None:
+            pass
+
+        scope: Scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/x",
+            "headers": [],
+            "state": {"outer_middleware": "present"},
+        }
+        await middleware(scope, receive, send)
+
+        assert seen["outer_middleware"] == "present"
+        assert "loopguard_request_id" in seen

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1163,3 +1163,74 @@ class TestSingleLogLinePerEvent:
         for ctx in contexts:
             assert ctx.request_id in message
             assert ctx.blocking_count == 1
+
+
+class TestCalibrationFailurePath:
+    """A failed calibration keeps the fallback and never raises into startup."""
+
+    @pytest.fixture(autouse=True)
+    def clear_registry(self) -> None:
+        """Clear the request registry before each test."""
+        get_registry().clear()
+
+    async def test_failed_background_calibration_keeps_fallback(self) -> None:
+        config = LoopGuardConfig(log_blocking_events=False, fallback_threshold_ms=50.0)
+
+        class ExplodingCalibration(SentinelMonitor):
+            async def calibrate(self) -> float:
+                raise RuntimeError("clock went sideways")
+
+        monitor = ExplodingCalibration(config)
+
+        # Must not raise into startup
+        await monitor.start_with_background_calibration()
+        await asyncio.sleep(0.05)  # let the background task fail
+
+        assert monitor.is_running
+        assert not monitor.is_calibrated
+        assert monitor.threshold_ms == config.fallback_threshold_ms
+
+        await monitor.stop()
+
+
+class TestMonitorLoopRecovery:
+    """An exception in the loop body must not kill the monitor."""
+
+    @pytest.fixture(autouse=True)
+    def clear_registry(self) -> None:
+        """Clear the request registry before each test."""
+        get_registry().clear()
+
+    async def test_monitor_loop_survives_handler_exception(self) -> None:
+        config = LoopGuardConfig(
+            monitor_interval_ms=2.0,
+            calibration_iterations=10,
+            fallback_threshold_ms=5.0,
+            log_blocking_events=False,
+        )
+        calls: list[float] = []
+
+        class FlakyHandler(SentinelMonitor):
+            def _handle_blocking(
+                self, lag_ms: float, is_cumulative: bool = False
+            ) -> None:
+                calls.append(lag_ms)
+                if len(calls) == 1:
+                    raise RuntimeError("handler hiccup")
+
+        monitor = FlakyHandler(config)
+        await monitor.start()
+        await asyncio.sleep(0.01)
+
+        time.sleep(0.05)  # first detection -> handler raises
+        await asyncio.sleep(0.01)
+        assert len(calls) == 1
+        assert monitor.is_running
+
+        await asyncio.sleep(1.1)  # ride out the error-recovery pause
+
+        time.sleep(0.05)  # second detection -> handler succeeds
+        await asyncio.sleep(0.01)
+
+        await monitor.stop()
+        assert len(calls) >= 2

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -278,3 +278,104 @@ class TestPytestPluginIntegration:
         assert "blocking event(s)" in stdout
         assert "max lag:" in stdout
         assert "threshold:" in stdout
+
+
+class TestPluginHygiene:
+    """Plugin behavior as an always-installed pytest11 entry point."""
+
+    def test_no_deprecation_warnings_under_error_filter(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """The plugin must survive a downstream -W error suite.
+
+        asyncio.iscoroutinefunction is deprecated on 3.14 and scheduled for
+        removal; the plugin auto-loads into every project that installs the
+        package, so its hooks may not emit deprecation warnings.
+        """
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+
+            @pytest.mark.no_blocking
+            async def test_clean():
+                await asyncio.sleep(0.01)
+        """)
+
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 50
+            filterwarnings =
+                error::DeprecationWarning
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+
+    def test_sync_test_with_marker_warns(self, pytester: pytest.Pytester) -> None:
+        """The marker on a sync test warns instead of silently no-opping."""
+        pytester.makepyfile("""
+            import pytest
+            import time
+
+            @pytest.mark.no_blocking
+            def test_sync_blocking():
+                time.sleep(0.05)
+        """)
+
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1, warnings=1)
+        assert "has no effect on synchronous test" in result.stdout.str()
+
+    def test_loopguard_detector_fixture_removed(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """The never-started detector fixture is gone.
+
+        It yielded a detector that was never started, so asserting on its
+        (always empty) blocking_events passed unconditionally.
+        """
+        pytester.makepyfile("""
+            def test_uses_fixture(loopguard_detector):
+                pass
+        """)
+
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(errors=1)
+        assert "loopguard_detector" in result.stdout.str()
+
+    def test_marked_test_that_raises_reports_original_error(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """A failing marked test fails with its own error, detector stopped."""
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+
+            @pytest.mark.no_blocking
+            async def test_raises():
+                await asyncio.sleep(0.01)
+                raise RuntimeError("the test itself is broken")
+        """)
+
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 50
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(failed=1)
+        assert "the test itself is broken" in result.stdout.str()
+        assert "Event loop blocking detected" not in result.stdout.str()


### PR DESCRIPTION
Stacked on #11 (extends the same test files) — merge that first, then retarget or merge this into it.

## Test gaps closed (from the coverage audit)

- Streaming multi-chunk bodies, 204/no-body responses, and `pathsend`/`trailers` extension messages through **all three** send wrappers (previously only strict mode was exercised).
- Duplicate and out-of-order lifespan events (double startup, startup after shutdown), `enabled=False` + lifespan, and pre-populated `scope["state"]` preservation.
- `exclude_paths`: custom sets, and a test documenting exact-match semantics (`/health/live` is NOT excluded by `/health` — FINDINGS #5 stays guarded).
- Strict mode: full 503 header contract (incl. `x-blocking-*` values and the deliberate absence of `x-blocking-detected`), clean pass-through headers, missing-`Accept` negotiation, and the bystander-503 behavior under concurrency (documents FINDINGS #3 by test).
- Calibration failure path (a raising `calibrate()` keeps the fallback and never raises into startup) and monitor-loop recovery from a handler exception.
- Cumulative window pruning by age and end-to-end cumulative attribution to request contexts.
- The four previously uncovered config validation branches.

## Plugin hygiene (pytest11 entry point — auto-loads into every downstream project)

- `asyncio.iscoroutinefunction` → `inspect.iscoroutinefunction`: deprecated on 3.14, removed in 3.16, and any downstream suite running `-W error::DeprecationWarning` failed inside a hook it never opted into. Regression test runs a marked test under that filter.
- `@pytest.mark.no_blocking` on a **sync** test now emits a warning instead of silently doing nothing.
- Removed the `loopguard_detector` fixture: it yielded a detector that was never started, so `assert not detector.blocking_events` passed unconditionally — structural false green. (API removal, flagged in CHANGELOG.)
- `BlockingDetector.stop()` gets the same cancellation-safety fix as the monitor (it runs in test `finally` blocks).

## Logging

- `configure_logging` is idempotent (replaces its own handler instead of stacking) and disables propagation so root-configured apps stop double-logging. Test fixtures restore logger state.
- `StructuredFormatter` preserves `exc_info` — the monitor's two `logger.exception` sites (failed calibration, crashed loop) previously lost their tracebacks in structured mode.

## CI honesty

`prometheus-client` joins the `dev` extra: `tests/test_metrics.py` importorskip-skipped silently in CI, leaving `metrics.py` at a permanent 0% and the 80% gate carried entirely by the other files.

## Verification

- `pytest -q`: **240 passed, 0 skipped** (was 190/1).
- `mypy src/` strict clean; ruff check + format clean.
- Coverage: **97% total** (was 89%).