### PR TITLE
AI-harness mode: all-async blocking gate + machine-readable report

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ Writes structured logs listing the requests that were in flight:
 
 ---
 
+## Testing AI-Generated Code
+
+AI agents write plausible async code that quietly blocks the event loop. The bundled pytest plugin turns that into a red test and a machine-readable report the agent can fix from — no per-test annotations:
+
+```ini
+# pytest.ini
+[pytest]
+loopguard_all_async = true          # every async test fails on blocking
+loopguard_report = loopguard.json   # verdicts + fix hints for the agent
+```
+
+See [docs/AI-HARNESS.md](docs/AI-HARNESS.md) for the report schema, the `no_blocking` / `allow_blocking` markers, and a drop-in snippet for your project's agent instructions.
+
+---
+
 <p align="center">
   <a href="docs/CONFIGURATION.md"><strong>Full Configuration Reference</strong></a>
 </p>

--- a/docs/AI-HARNESS.md
+++ b/docs/AI-HARNESS.md
@@ -1,0 +1,111 @@
+# LoopGuard as a Test Harness for AI-Generated Code
+
+AI coding agents write plausible async code that quietly blocks the event
+loop — `requests` instead of `httpx`, `open().read()` in a handler, a sync
+SDK call inside `async def`. The type checker passes, the tests pass, and
+the app freezes under load.
+
+LoopGuard's pytest plugin turns that failure mode into a red test with a
+machine-readable explanation the agent can fix from — no per-test
+annotations required.
+
+## Quick start
+
+```ini
+# pytest.ini (or [tool.pytest.ini_options] in pyproject.toml)
+[pytest]
+asyncio_mode = auto
+loopguard_all_async = true          # every async test is a blocking gate
+loopguard_report = loopguard.json   # verdicts for the agent to read
+loopguard_threshold_ms = 50
+```
+
+Run the suite as usual:
+
+```bash
+pytest
+```
+
+Any async test whose execution blocks the event loop past the threshold
+fails, and `loopguard.json` records what happened. Both settings also
+exist as CLI flags: `--loopguard-all-async`, `--loopguard-report=PATH`.
+
+## Options
+
+| Option | Where | Default | Meaning |
+|--------|-------|---------|---------|
+| `loopguard_threshold_ms` | ini | `50` | Lag beyond this fails the test |
+| `loopguard_all_async` | ini / `--loopguard-all-async` | off | Treat every async test as `@pytest.mark.no_blocking` |
+| `loopguard_report` | ini / `--loopguard-report=PATH` | off | Write the JSON verdict file |
+| `@pytest.mark.no_blocking` | marker | — | Gate one test explicitly (works without all-async mode) |
+| `@pytest.mark.allow_blocking` | marker | — | Exempt one test from all-async mode |
+
+Exit semantics are plain pytest: flagged tests fail, so any CI that runs
+pytest is already enforcing the gate.
+
+## The report
+
+```json
+{
+  "schema_version": 1,
+  "threshold_ms": 50.0,
+  "totals": {"tests": 42, "flagged": 1},
+  "tests": [
+    {
+      "nodeid": "tests/test_api.py::test_upload",
+      "verdict": "blocked",
+      "events": [{"lag_ms": 180.24, "threshold_ms": 50.0}],
+      "hints": [
+        "time.sleep(n) -> await asyncio.sleep(n)",
+        "requests.get(url) -> await httpx.AsyncClient().get(url)",
+        "open(f).read() -> await aiofiles.open(f)",
+        "subprocess.run(...) -> await asyncio.create_subprocess_exec(...)",
+        "CPU-bound work -> await asyncio.to_thread(func)"
+      ]
+    },
+    {
+      "nodeid": "tests/test_api.py::test_list",
+      "verdict": "clean",
+      "events": [],
+      "hints": []
+    }
+  ]
+}
+```
+
+Only instrumented tests appear (`totals.tests` counts them). A `blocked`
+verdict means the loop lagged past the threshold while that test ran; the
+sentinel measures lag, not call stacks, so the culprit is in the code that
+test executed — usually the endpoint it called.
+
+## Interpreting the strict 503 (runtime harness)
+
+For integration tests that drive a live app, run the middleware with
+`LoopGuardConfig(enforcement_mode="strict")`: blocking requests fail with
+a 503 whose JSON body carries the same shape of diagnosis
+(`error: "event_loop_blocked"`, blocking count and total ms, and the same
+fix suggestions under `help.common_causes`).
+
+## Drop-in snippet for a consumer project's CLAUDE.md / agents.md
+
+```markdown
+## Async discipline (enforced)
+
+This project gates async code with fastapi-loopguard. `pytest` fails any
+async test that blocks the event loop for >50ms and writes verdicts to
+`loopguard.json`.
+
+When a test fails with "Event loop blocking detected":
+1. Read `loopguard.json`; find the `blocked` entry for that test.
+2. The blocking call is in the code path that test exercises. Replace
+   sync calls with the async equivalents listed under `hints`.
+3. Never widen `loopguard_threshold_ms` or add `allow_blocking` to make
+   a test pass — fix the blocking call instead.
+```
+
+## Scoring models instead of guarding CI
+
+The same gate scores whether a model writes non-blocking async code: run
+each generated solution against a functional test file plus the plugin,
+and read `totals.flagged` from the report. A ready-made task set lives in
+`evals/` at the repository root.

--- a/src/fastapi_loopguard/pytest_plugin.py
+++ b/src/fastapi_loopguard/pytest_plugin.py
@@ -12,25 +12,55 @@ Usage:
     async def test_my_endpoint():
         # If this test blocks the event loop, it will fail
         ...
+
+Harness mode (for CI gates over AI-generated or unfamiliar code):
+    # pytest.ini
+    [pytest]
+    loopguard_all_async = true          # every async test is checked
+    loopguard_report = loopguard.json   # machine-readable results
+
+    Opt a test out with @pytest.mark.allow_blocking. Both options also
+    exist as CLI flags: --loopguard-all-async, --loopguard-report=PATH.
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
+import json
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 # Marker for tests that should fail on blocking
 MARKER_NAME = "no_blocking"
+# Opt-out marker for loopguard_all_async mode
+ALLOW_MARKER_NAME = "allow_blocking"
+
+# Per-session records for the machine-readable report
+_REPORT_KEY: pytest.StashKey[list[dict[str, Any]]] = pytest.StashKey()
+
+# Suggested rewrites included with every "blocked" verdict so an agent
+# consuming the report can act without extra context
+_FIX_HINTS = [
+    "time.sleep(n) -> await asyncio.sleep(n)",
+    "requests.get(url) -> await httpx.AsyncClient().get(url)",
+    "open(f).read() -> await aiofiles.open(f)",
+    "subprocess.run(...) -> await asyncio.create_subprocess_exec(...)",
+    "CPU-bound work -> await asyncio.to_thread(func)",
+]
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the no_blocking marker."""
+    """Register the markers."""
     config.addinivalue_line(
         "markers",
         f"{MARKER_NAME}: fail test if event loop blocking is detected",
+    )
+    config.addinivalue_line(
+        "markers",
+        f"{ALLOW_MARKER_NAME}: exempt this test from loopguard_all_async mode",
     )
 
 
@@ -41,6 +71,33 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "Blocking detection threshold in milliseconds",
         type="string",
         default="50",
+    )
+    parser.addini(
+        "loopguard_all_async",
+        "Treat every async test as @pytest.mark.no_blocking",
+        type="bool",
+        default=False,
+    )
+    parser.addini(
+        "loopguard_report",
+        "Path to write a JSON report of blocking verdicts",
+        type="string",
+        default="",
+    )
+    group = parser.getgroup("loopguard")
+    group.addoption(
+        "--loopguard-all-async",
+        action="store_true",
+        default=False,
+        dest="loopguard_all_async",
+        help="Treat every async test as @pytest.mark.no_blocking",
+    )
+    group.addoption(
+        "--loopguard-report",
+        action="store",
+        default="",
+        dest="loopguard_report",
+        help="Path to write a JSON report of blocking verdicts",
     )
 
 
@@ -91,35 +148,56 @@ class BlockingDetector:
                 self.blocking_events.append(lag_ms)
 
 
+def _threshold_ms(config: pytest.Config) -> float:
+    threshold_str = config.getini("loopguard_threshold_ms")
+    return float(threshold_str) if threshold_str else 50.0
+
+
+def _all_async_enabled(config: pytest.Config) -> bool:
+    return bool(
+        config.getoption("loopguard_all_async") or config.getini("loopguard_all_async")
+    )
+
+
+def _report_path(config: pytest.Config) -> str:
+    return str(
+        config.getoption("loopguard_report") or config.getini("loopguard_report")
+    )
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_call(item: pytest.Item) -> None:
-    """Check for blocking after test execution."""
-    marker = item.get_closest_marker(MARKER_NAME)
-    if marker is None:
-        return
-
+    """Instrument marked (or, in all-async mode, every async) test."""
     # Only works with Function items (which have obj attribute)
     if not isinstance(item, pytest.Function):
         return
+
+    explicit = item.get_closest_marker(MARKER_NAME) is not None
+    if not explicit:
+        if item.get_closest_marker(ALLOW_MARKER_NAME) is not None:
+            return
+        if not _all_async_enabled(item.config):
+            return
 
     # Store the original test function
     original_func = item.obj
 
     if not inspect.iscoroutinefunction(original_func):
-        # A sync test never runs on the event loop; silently passing would
-        # let the author believe blocking was checked
-        item.warn(
-            pytest.PytestWarning(
-                f"@pytest.mark.{MARKER_NAME} has no effect on synchronous "
-                f"test {item.nodeid}: there is no event loop to monitor"
+        # A sync test never runs on the event loop. In all-async mode it is
+        # silently out of scope; with an explicit marker, silently passing
+        # would let the author believe blocking was checked
+        if explicit:
+            item.warn(
+                pytest.PytestWarning(
+                    f"@pytest.mark.{MARKER_NAME} has no effect on synchronous "
+                    f"test {item.nodeid}: there is no event loop to monitor"
+                )
             )
-        )
         return
 
     # Wrap async test with blocking detection
     async def wrapped(*args: Any, **kwargs: Any) -> Any:
-        threshold_str = item.config.getini("loopguard_threshold_ms")
-        threshold = float(threshold_str) if threshold_str else 50.0
+        threshold = _threshold_ms(item.config)
 
         detector = BlockingDetector(threshold_ms=threshold)
         await detector.start()
@@ -129,14 +207,48 @@ def pytest_runtest_call(item: pytest.Item) -> None:
         finally:
             await detector.stop()
 
-        if detector.blocking_events:
-            max_lag = max(detector.blocking_events)
+        events = list(detector.blocking_events)
+        records = item.config.stash.setdefault(_REPORT_KEY, [])
+        records.append(
+            {
+                "nodeid": item.nodeid,
+                "verdict": "blocked" if events else "clean",
+                "events": [
+                    {"lag_ms": round(lag, 2), "threshold_ms": threshold}
+                    for lag in events
+                ],
+                "hints": _FIX_HINTS if events else [],
+            }
+        )
+
+        if events:
+            max_lag = max(events)
             pytest.fail(
                 f"Event loop blocking detected! "
-                f"{len(detector.blocking_events)} blocking event(s), "
+                f"{len(events)} blocking event(s), "
                 f"max lag: {max_lag:.2f}ms (threshold: {threshold}ms)"
             )
 
         return result
 
     item.obj = wrapped
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Write the machine-readable report if a path was configured."""
+    config = session.config
+    path = _report_path(config)
+    if not path:
+        return
+
+    records = config.stash.get(_REPORT_KEY, [])
+    report = {
+        "schema_version": 1,
+        "threshold_ms": _threshold_ms(config),
+        "totals": {
+            "tests": len(records),
+            "flagged": sum(1 for r in records if r["verdict"] == "blocked"),
+        },
+        "tests": records,
+    }
+    Path(path).write_text(json.dumps(report, indent=2))

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 
 import pytest
@@ -379,3 +380,167 @@ class TestPluginHygiene:
         result.assert_outcomes(failed=1)
         assert "the test itself is broken" in result.stdout.str()
         assert "Event loop blocking detected" not in result.stdout.str()
+
+
+class TestAllAsyncMode:
+    """loopguard_all_async: the harness switch for unannotated test suites."""
+
+    def _make_suite(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+            import time
+
+            async def test_blocks():
+                await asyncio.sleep(0.02)
+                time.sleep(0.2)
+                await asyncio.sleep(0.02)
+
+            async def test_clean():
+                await asyncio.sleep(0.01)
+
+            @pytest.mark.allow_blocking
+            async def test_opted_out():
+                time.sleep(0.2)
+        """)
+
+    def test_ini_flags_unmarked_blocking_test(self, pytester: pytest.Pytester) -> None:
+        self._make_suite(pytester)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+            loopguard_all_async = true
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(failed=1, passed=2)
+        assert "Event loop blocking detected" in result.stdout.str()
+
+    def test_cli_flag_equivalent(self, pytester: pytest.Pytester) -> None:
+        self._make_suite(pytester)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+        """)
+
+        result = pytester.runpytest("-v", "--loopguard-all-async")
+        result.assert_outcomes(failed=1, passed=2)
+
+    def test_off_by_default(self, pytester: pytest.Pytester) -> None:
+        self._make_suite(pytester)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=3)
+
+    def test_sync_tests_out_of_scope_without_warning(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """All-async mode skips sync tests silently (no marker, no warning)."""
+        pytester.makepyfile("""
+            import time
+
+            def test_sync_blocks():
+                time.sleep(0.05)
+        """)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+            loopguard_all_async = true
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1, warnings=0)
+
+
+class TestJsonReport:
+    """--loopguard-report: the machine-readable verdict file."""
+
+    def test_report_written_with_verdicts_and_hints(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+            import time
+
+            @pytest.mark.no_blocking
+            async def test_blocks():
+                await asyncio.sleep(0.02)
+                time.sleep(0.2)
+                await asyncio.sleep(0.02)
+
+            @pytest.mark.no_blocking
+            async def test_clean():
+                await asyncio.sleep(0.01)
+        """)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+        """)
+
+        result = pytester.runpytest("-v", "--loopguard-report=loopguard.json")
+        result.assert_outcomes(failed=1, passed=1)
+
+        report_file = pytester.path / "loopguard.json"
+        assert report_file.exists()
+        report = json.loads(report_file.read_text())
+
+        assert report["schema_version"] == 1
+        assert report["threshold_ms"] == 10.0
+        assert report["totals"] == {"tests": 2, "flagged": 1}
+
+        by_verdict = {r["verdict"]: r for r in report["tests"]}
+        blocked = by_verdict["blocked"]
+        assert "test_blocks" in blocked["nodeid"]
+        assert blocked["events"][0]["lag_ms"] > 10.0
+        assert any("time.sleep" in hint for hint in blocked["hints"])
+
+        clean = by_verdict["clean"]
+        assert clean["events"] == []
+        assert clean["hints"] == []
+
+    def test_ini_report_path(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+
+            @pytest.mark.no_blocking
+            async def test_clean():
+                await asyncio.sleep(0.01)
+        """)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_report = from-ini.json
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+        assert (pytester.path / "from-ini.json").exists()
+
+    def test_no_report_without_option(self, pytester: pytest.Pytester) -> None:
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+
+            @pytest.mark.no_blocking
+            async def test_clean():
+                await asyncio.sleep(0.01)
+        """)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+        assert not list(pytester.path.glob("*.json"))


### PR DESCRIPTION
Stacked on #12 (which stacks on #11).

## What

Turns the pytest plugin into a first-class harness for AI-generated code — the "agent wrote it, the harness decides" gate:

- **`loopguard_all_async`** (ini or `--loopguard-all-async`): every async test is treated as `@pytest.mark.no_blocking`, no annotations needed. `@pytest.mark.allow_blocking` opts a single test out. Sync tests are silently out of scope in this mode (no loop to monitor); the explicit marker still warns on sync tests.
- **`loopguard_report`** (ini or `--loopguard-report=PATH`): a JSON verdict file written at session end — per-test `blocked`/`clean` verdict, lag events with the threshold, and concrete `sync -> async` fix hints an agent can apply without extra context:

```json
{"schema_version": 1, "threshold_ms": 10.0,
 "totals": {"tests": 2, "flagged": 1},
 "tests": [{"nodeid": "test_api.py::test_upload", "verdict": "blocked",
            "events": [{"lag_ms": 180.24, "threshold_ms": 10.0}],
            "hints": ["time.sleep(n) -> await asyncio.sleep(n)", "..."]}]}
```

- Exit semantics unchanged: flagged tests fail through the existing marker mechanism, so plain `pytest` in CI is already the gate. The report path is stdlib-`json`, written once at `sessionfinish`, zero cost when unconfigured — hooks stay cheap for unmarked runs per the plugin's public-API rule.
- **docs/AI-HARNESS.md**: options table, report schema, how to interpret the strict-mode 503 JSON in integration tests, and a drop-in snippet for a consumer project's CLAUDE.md/agents.md.
- **README**: "Testing AI-Generated Code" section linking the doc.

## Verification

- 7 new `pytester` end-to-end tests: ini and CLI forms of both options, opt-out marker, off-by-default, sync-test scoping, report content (verdicts, events, hints), and no-report-without-option.
- `pytest -q`: 247 passed. `mypy src/` strict clean; ruff clean; coverage 97%.