### PR TITLE
evals/: benchmark scaffold for scoring AI models on non-blocking code

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,64 @@
+# LoopGuard Evals
+
+A small benchmark that scores whether an AI model writes **non-blocking**
+async FastAPI code. Each task ships a prompt, a provided `helpers.py`, and
+functional checks; LoopGuard's pytest plugin is the judge.
+
+The trap is always the same shape: `helpers.py` offers a slow synchronous
+function (and sometimes an async variant). A correct solution keeps the
+event loop free — by using the async variant or wrapping the sync one in
+`asyncio.to_thread` — while a naive solution calls the sync helper directly
+and blocks the loop for 100–200 ms, which the plugin flags deterministically
+against the 50 ms threshold.
+
+## Layout
+
+```
+evals/
+  runner.py                     score one solution against one task
+  tasks/<name>/
+    task.md                     the prompt to give the model
+    app_skeleton.py             starting file the model completes
+    helpers.py                  provided API (contains the trap)
+    checks.py                   functional pytest checks
+    reference/clean.py          known-good solution (ground truth)
+    reference/blocking.py       known-blocking solution (ground truth)
+```
+
+`reference/` is ground truth for validating the harness — exclude it from
+any context you give the model under test.
+
+## Running
+
+```bash
+pip install -e ".[dev]"      # from the repository root
+
+python evals/runner.py \
+  --task evals/tasks/01-user-lookup \
+  --solution path/to/model_output.py
+```
+
+Output (also written with `--out scores.json`):
+
+```json
+{
+  "task": "01-user-lookup",
+  "functional": true,
+  "non_blocking": false,
+  "score": 0,
+  "flagged": ["test_checks.py::test_returns_user"],
+  "detail": "1 test(s) blocked the event loop"
+}
+```
+
+`score` is 1 only when every check passes **and** nothing blocked the loop.
+To benchmark a model, generate one solution per task from `task.md` (plus
+`app_skeleton.py` and `helpers.py` as context) and sum the scores.
+
+## Scoring semantics
+
+| exit | blocked verdicts | functional | non_blocking | score |
+|------|------------------|------------|--------------|-------|
+| 0    | none             | true       | true         | 1     |
+| ≠0   | ≥1               | unknown    | false        | 0     |
+| ≠0   | none             | false      | true         | 0     |

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -1,0 +1,104 @@
+"""Score one solution file against one eval task.
+
+Usage:
+    python evals/runner.py --task evals/tasks/01-user-lookup \
+        --solution path/to/app.py [--out scores.json]
+
+Copies the solution, the task's helpers and checks into a temp directory,
+runs pytest there with LoopGuard's all-async gate and JSON report, and
+reduces the result to a single score.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PYTEST_INI = """\
+[pytest]
+asyncio_mode = auto
+loopguard_threshold_ms = 50
+loopguard_all_async = true
+loopguard_report = loopguard-report.json
+"""
+
+
+def score_task(task_dir: Path, solution: Path) -> dict[str, object]:
+    """Run one task's checks against one solution; return the score record."""
+    with tempfile.TemporaryDirectory(prefix="loopguard-eval-") as tmp:
+        workdir = Path(tmp)
+        shutil.copy(solution, workdir / "app.py")
+        shutil.copy(task_dir / "helpers.py", workdir / "helpers.py")
+        shutil.copy(task_dir / "checks.py", workdir / "test_checks.py")
+        (workdir / "pytest.ini").write_text(PYTEST_INI)
+
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "--color=no"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        report_path = workdir / "loopguard-report.json"
+        blocked: list[str] = []
+        if report_path.exists():
+            report = json.loads(report_path.read_text())
+            blocked = [
+                record["nodeid"]
+                for record in report["tests"]
+                if record["verdict"] == "blocked"
+            ]
+
+    non_blocking = not blocked
+    passed = proc.returncode == 0
+
+    if passed:
+        detail = "all checks passed without blocking"
+        functional: bool | str = True
+    elif blocked:
+        detail = f"{len(blocked)} test(s) blocked the event loop"
+        functional = "unknown"
+    else:
+        detail = "functional checks failed"
+        functional = False
+
+    return {
+        "task": task_dir.name,
+        "functional": functional,
+        "non_blocking": non_blocking,
+        "score": 1 if passed else 0,
+        "flagged": blocked,
+        "detail": detail,
+        "pytest_tail": proc.stdout.strip().splitlines()[-3:],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task", required=True, type=Path)
+    parser.add_argument("--solution", required=True, type=Path)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    for name in ("helpers.py", "checks.py"):
+        if not (args.task / name).exists():
+            parser.error(f"{args.task} is missing {name}")
+    if not args.solution.exists():
+        parser.error(f"solution not found: {args.solution}")
+
+    result = score_task(args.task, args.solution)
+    output = json.dumps(result, indent=2)
+    print(output)
+    if args.out:
+        args.out.write_text(output)
+    return 0 if result["score"] == 1 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/tasks/01-user-lookup/app_skeleton.py
+++ b/evals/tasks/01-user-lookup/app_skeleton.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+import helpers  # noqa: F401  (the provided API)
+
+app = FastAPI()
+
+
+# TODO: implement GET /users/{user_id} using helpers

--- a/evals/tasks/01-user-lookup/checks.py
+++ b/evals/tasks/01-user-lookup/checks.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from httpx import ASGITransport, AsyncClient
+
+from app import app
+
+
+async def test_returns_user():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.get("/users/42")
+    await asyncio.sleep(0.02)  # let the sentinel record any pending lag
+
+    assert response.status_code == 200
+    assert response.json() == {"id": 42, "name": "user-42"}

--- a/evals/tasks/01-user-lookup/helpers.py
+++ b/evals/tasks/01-user-lookup/helpers.py
@@ -1,0 +1,16 @@
+"""Provided API. Do not modify."""
+
+import asyncio
+import time
+
+
+def load_user(user_id: int) -> dict:
+    """Load a user record. Synchronous: ~150ms of blocking I/O."""
+    time.sleep(0.15)
+    return {"id": user_id, "name": f"user-{user_id}"}
+
+
+async def aload_user(user_id: int) -> dict:
+    """Async variant of load_user."""
+    await asyncio.sleep(0.15)
+    return {"id": user_id, "name": f"user-{user_id}"}

--- a/evals/tasks/01-user-lookup/reference/blocking.py
+++ b/evals/tasks/01-user-lookup/reference/blocking.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: int) -> dict:
+    return helpers.load_user(user_id)  # blocks the loop for ~150ms

--- a/evals/tasks/01-user-lookup/reference/clean.py
+++ b/evals/tasks/01-user-lookup/reference/clean.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: int) -> dict:
+    return await helpers.aload_user(user_id)

--- a/evals/tasks/01-user-lookup/task.md
+++ b/evals/tasks/01-user-lookup/task.md
@@ -1,0 +1,11 @@
+# Task: user lookup endpoint
+
+Complete `app_skeleton.py` (save your result as `app.py`).
+
+Implement `GET /users/{user_id}`:
+- Load the user with the API provided in `helpers.py`.
+- Return the user dict as JSON with status 200.
+
+Constraints:
+- The endpoint must not block the event loop.
+- Use only `helpers.py` and the standard library.

--- a/evals/tasks/02-price-fanout/app_skeleton.py
+++ b/evals/tasks/02-price-fanout/app_skeleton.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+import helpers  # noqa: F401  (the provided API)
+
+app = FastAPI()
+
+
+# TODO: implement GET /portfolio?symbols=AAA,BBB,CCC using helpers

--- a/evals/tasks/02-price-fanout/checks.py
+++ b/evals/tasks/02-price-fanout/checks.py
@@ -1,0 +1,20 @@
+import asyncio
+import time
+
+from httpx import ASGITransport, AsyncClient
+
+from app import app
+
+
+async def test_prices_fetched_concurrently():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        start = time.monotonic()
+        response = await client.get("/portfolio", params={"symbols": "AAA,BBB,CCC"})
+        elapsed = time.monotonic() - start
+    await asyncio.sleep(0.02)  # let the sentinel record any pending lag
+
+    assert response.status_code == 200
+    assert response.json() == {"prices": {"AAA": 30.0, "BBB": 30.0, "CCC": 30.0}}
+    # Concurrent: ~1 fetch (~0.12s). Sequential would be >= 0.36s.
+    assert elapsed < 0.30

--- a/evals/tasks/02-price-fanout/helpers.py
+++ b/evals/tasks/02-price-fanout/helpers.py
@@ -1,0 +1,16 @@
+"""Provided API. Do not modify."""
+
+import asyncio
+import time
+
+
+def fetch_price(symbol: str) -> float:
+    """Fetch one price. Synchronous: ~120ms of blocking I/O."""
+    time.sleep(0.12)
+    return float(len(symbol)) * 10.0
+
+
+async def afetch_price(symbol: str) -> float:
+    """Async variant of fetch_price."""
+    await asyncio.sleep(0.12)
+    return float(len(symbol)) * 10.0

--- a/evals/tasks/02-price-fanout/reference/blocking.py
+++ b/evals/tasks/02-price-fanout/reference/blocking.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.get("/portfolio")
+async def portfolio(symbols: str) -> dict:
+    names = symbols.split(",")
+    prices = {s: helpers.fetch_price(s) for s in names}  # blocks 3x
+    return {"prices": prices}

--- a/evals/tasks/02-price-fanout/reference/clean.py
+++ b/evals/tasks/02-price-fanout/reference/clean.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.get("/portfolio")
+async def portfolio(symbols: str) -> dict:
+    names = symbols.split(",")
+    prices = await asyncio.gather(*(helpers.afetch_price(s) for s in names))
+    return {"prices": dict(zip(names, prices, strict=True))}

--- a/evals/tasks/02-price-fanout/task.md
+++ b/evals/tasks/02-price-fanout/task.md
@@ -1,0 +1,13 @@
+# Task: portfolio price fan-out
+
+Complete `app_skeleton.py` (save your result as `app.py`).
+
+Implement `GET /portfolio?symbols=AAA,BBB,CCC`:
+- Fetch the price of every symbol with the API in `helpers.py`.
+- Fetch them concurrently: total latency must stay close to one fetch,
+  not the sum of all fetches.
+- Return `{"prices": {symbol: price, ...}}` with status 200.
+
+Constraints:
+- The endpoint must not block the event loop.
+- Use only `helpers.py` and the standard library.

--- a/evals/tasks/03-report-export/app_skeleton.py
+++ b/evals/tasks/03-report-export/app_skeleton.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+import helpers  # noqa: F401  (the provided API)
+
+app = FastAPI()
+
+
+# TODO: implement POST /reports using helpers.render_report

--- a/evals/tasks/03-report-export/checks.py
+++ b/evals/tasks/03-report-export/checks.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from httpx import ASGITransport, AsyncClient
+
+from app import app
+
+
+async def test_renders_report():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.post("/reports", json={"rows": ["a", "b", "c"]})
+    await asyncio.sleep(0.02)  # let the sentinel record any pending lag
+
+    assert response.status_code == 200
+    assert response.json() == {"length": 5}  # "a\nb\nc"

--- a/evals/tasks/03-report-export/helpers.py
+++ b/evals/tasks/03-report-export/helpers.py
@@ -1,0 +1,9 @@
+"""Provided API. Do not modify."""
+
+import time
+
+
+def render_report(rows: list) -> str:
+    """Render rows to a report. CPU-bound: ~150ms, holds the GIL."""
+    time.sleep(0.15)  # stands in for real CPU work
+    return "\n".join(str(row) for row in rows)

--- a/evals/tasks/03-report-export/reference/blocking.py
+++ b/evals/tasks/03-report-export/reference/blocking.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.post("/reports")
+async def create_report(payload: dict) -> dict:
+    rendered = helpers.render_report(payload["rows"])  # blocks ~150ms
+    return {"length": len(rendered)}

--- a/evals/tasks/03-report-export/reference/clean.py
+++ b/evals/tasks/03-report-export/reference/clean.py
@@ -1,0 +1,13 @@
+import asyncio
+
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.post("/reports")
+async def create_report(payload: dict) -> dict:
+    rendered = await asyncio.to_thread(helpers.render_report, payload["rows"])
+    return {"length": len(rendered)}

--- a/evals/tasks/03-report-export/task.md
+++ b/evals/tasks/03-report-export/task.md
@@ -1,0 +1,14 @@
+# Task: CPU-bound report rendering
+
+Complete `app_skeleton.py` (save your result as `app.py`).
+
+Implement `POST /reports` accepting `{"rows": [...]}`:
+- Render the report with `helpers.render_report(rows)`.
+- Return `{"length": <len of rendered string>}` with status 200.
+
+Note: `helpers.py` has no async variant this time - rendering is
+CPU-bound. Keeping the event loop free is still your responsibility.
+
+Constraints:
+- The endpoint must not block the event loop.
+- Use only `helpers.py` and the standard library.

--- a/evals/tasks/04-image-thumbnail/app_skeleton.py
+++ b/evals/tasks/04-image-thumbnail/app_skeleton.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI, Request
+
+import helpers  # noqa: F401  (the provided API)
+
+app = FastAPI()
+
+
+# TODO: implement POST /thumbnail using helpers.resize_image

--- a/evals/tasks/04-image-thumbnail/checks.py
+++ b/evals/tasks/04-image-thumbnail/checks.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from httpx import ASGITransport, AsyncClient
+
+from app import app
+
+
+async def test_thumbnail_size():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.post("/thumbnail", content=b"x" * 100)
+    await asyncio.sleep(0.02)  # let the sentinel record any pending lag
+
+    assert response.status_code == 200
+    assert response.json() == {"size": 25}

--- a/evals/tasks/04-image-thumbnail/helpers.py
+++ b/evals/tasks/04-image-thumbnail/helpers.py
@@ -1,0 +1,9 @@
+"""Provided API. Do not modify."""
+
+import time
+
+
+def resize_image(data: bytes) -> bytes:
+    """Resize image bytes to a thumbnail. CPU-bound: ~150ms."""
+    time.sleep(0.15)  # stands in for real pixel work
+    return data[: max(1, len(data) // 4)]

--- a/evals/tasks/04-image-thumbnail/reference/blocking.py
+++ b/evals/tasks/04-image-thumbnail/reference/blocking.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI, Request
+
+import helpers
+
+app = FastAPI()
+
+
+@app.post("/thumbnail")
+async def thumbnail(request: Request) -> dict:
+    data = await request.body()
+    thumb = helpers.resize_image(data)  # blocks ~150ms
+    return {"size": len(thumb)}

--- a/evals/tasks/04-image-thumbnail/reference/clean.py
+++ b/evals/tasks/04-image-thumbnail/reference/clean.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from fastapi import FastAPI, Request
+
+import helpers
+
+app = FastAPI()
+
+
+@app.post("/thumbnail")
+async def thumbnail(request: Request) -> dict:
+    data = await request.body()
+    thumb = await asyncio.to_thread(helpers.resize_image, data)
+    return {"size": len(thumb)}

--- a/evals/tasks/04-image-thumbnail/task.md
+++ b/evals/tasks/04-image-thumbnail/task.md
@@ -1,0 +1,13 @@
+# Task: image thumbnail endpoint
+
+Complete `app_skeleton.py` (save your result as `app.py`).
+
+Implement `POST /thumbnail` accepting a raw request body of image bytes:
+- Produce a thumbnail with `helpers.resize_image(data)`.
+- Return `{"size": <len of thumbnail bytes>}` with status 200.
+
+Note: `helpers.py` has no async variant - resizing is CPU-bound.
+
+Constraints:
+- The endpoint must not block the event loop.
+- Use only `helpers.py`, FastAPI's `Request`, and the standard library.

--- a/evals/tasks/05-audit-log/app_skeleton.py
+++ b/evals/tasks/05-audit-log/app_skeleton.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+import helpers  # noqa: F401  (the provided API)
+
+app = FastAPI()
+
+
+# TODO: implement POST /orders using helpers

--- a/evals/tasks/05-audit-log/checks.py
+++ b/evals/tasks/05-audit-log/checks.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from httpx import ASGITransport, AsyncClient
+
+import helpers
+from app import app
+
+
+async def test_creates_order_with_audit_line():
+    helpers.AUDIT.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.post("/orders", json={"item": "widget"})
+    await asyncio.sleep(0.02)  # let the sentinel record any pending lag
+
+    assert response.status_code == 201
+    assert response.json() == {"status": "created"}
+    assert helpers.AUDIT == ["order:widget"]

--- a/evals/tasks/05-audit-log/helpers.py
+++ b/evals/tasks/05-audit-log/helpers.py
@@ -1,0 +1,18 @@
+"""Provided API. Do not modify."""
+
+import asyncio
+import time
+
+AUDIT: list[str] = []
+
+
+def append_audit_line(line: str) -> None:
+    """Append to the audit trail. Synchronous: ~120ms of blocking I/O."""
+    time.sleep(0.12)
+    AUDIT.append(line)
+
+
+async def aappend_audit_line(line: str) -> None:
+    """Async variant of append_audit_line."""
+    await asyncio.sleep(0.12)
+    AUDIT.append(line)

--- a/evals/tasks/05-audit-log/reference/blocking.py
+++ b/evals/tasks/05-audit-log/reference/blocking.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.post("/orders", status_code=201)
+async def create_order(payload: dict) -> dict:
+    helpers.append_audit_line(f"order:{payload['item']}")  # blocks ~120ms
+    return {"status": "created"}

--- a/evals/tasks/05-audit-log/reference/clean.py
+++ b/evals/tasks/05-audit-log/reference/clean.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+import helpers
+
+app = FastAPI()
+
+
+@app.post("/orders", status_code=201)
+async def create_order(payload: dict) -> dict:
+    await helpers.aappend_audit_line(f"order:{payload['item']}")
+    return {"status": "created"}

--- a/evals/tasks/05-audit-log/task.md
+++ b/evals/tasks/05-audit-log/task.md
@@ -1,0 +1,11 @@
+# Task: order creation with audit trail
+
+Complete `app_skeleton.py` (save your result as `app.py`).
+
+Implement `POST /orders` accepting `{"item": "<name>"}`:
+- Append an audit line `"order:<name>"` using the API in `helpers.py`.
+- Return `{"status": "created"}` with status 201.
+
+Constraints:
+- The endpoint must not block the event loop.
+- Use only `helpers.py` and the standard library.

--- a/src/fastapi_loopguard/pytest_plugin.py
+++ b/src/fastapi_loopguard/pytest_plugin.py
@@ -111,9 +111,16 @@ class BlockingDetector:
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
-        """Start the blocking detector."""
+        """Start the blocking detector.
+
+        Yields once so the monitor task reaches its first sleep before the
+        caller continues: without this, a test that blocks before its first
+        real await (an ASGI request dispatch does exactly that) blocks an
+        unarmed sentinel and is never measured.
+        """
         self._running = True
         self._task = asyncio.create_task(self._monitor())
+        await asyncio.sleep(0)
 
     async def stop(self) -> None:
         """Stop the blocking detector.
@@ -205,21 +212,22 @@ def pytest_runtest_call(item: pytest.Item) -> None:
         try:
             result = await original_func(*args, **kwargs)
         finally:
+            # Record in the finally so a test that both blocks AND fails
+            # functionally still lands its "blocked" verdict in the report
             await detector.stop()
-
-        events = list(detector.blocking_events)
-        records = item.config.stash.setdefault(_REPORT_KEY, [])
-        records.append(
-            {
-                "nodeid": item.nodeid,
-                "verdict": "blocked" if events else "clean",
-                "events": [
-                    {"lag_ms": round(lag, 2), "threshold_ms": threshold}
-                    for lag in events
-                ],
-                "hints": _FIX_HINTS if events else [],
-            }
-        )
+            events = list(detector.blocking_events)
+            records = item.config.stash.setdefault(_REPORT_KEY, [])
+            records.append(
+                {
+                    "nodeid": item.nodeid,
+                    "verdict": "blocked" if events else "clean",
+                    "events": [
+                        {"lag_ms": round(lag, 2), "threshold_ms": threshold}
+                        for lag in events
+                    ],
+                    "hints": _FIX_HINTS if events else [],
+                }
+            )
 
         if events:
             max_lag = max(events)

--- a/tests/test_evals_runner.py
+++ b/tests/test_evals_runner.py
@@ -1,0 +1,57 @@
+"""Ground-truth validation of the evals harness.
+
+One full task scored against its known-clean and known-blocking reference
+solutions, through the real runner CLI (which itself runs pytest in a
+subprocess with the plugin's all-async gate).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+RUNNER = REPO_ROOT / "evals" / "runner.py"
+TASK = REPO_ROOT / "evals" / "tasks" / "01-user-lookup"
+
+
+def _run(solution: Path) -> tuple[int, dict[str, object]]:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--task",
+            str(TASK),
+            "--solution",
+            str(solution),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=REPO_ROOT,
+    )
+    return proc.returncode, json.loads(proc.stdout)
+
+
+class TestEvalsGroundTruth:
+    """The harness must separate the reference solutions."""
+
+    def test_clean_reference_scores_one(self) -> None:
+        returncode, result = _run(TASK / "reference" / "clean.py")
+
+        assert returncode == 0
+        assert result["score"] == 1
+        assert result["functional"] is True
+        assert result["non_blocking"] is True
+        assert result["flagged"] == []
+
+    def test_blocking_reference_scores_zero(self) -> None:
+        returncode, result = _run(TASK / "reference" / "blocking.py")
+
+        assert returncode == 1
+        assert result["score"] == 0
+        assert result["non_blocking"] is False
+        assert len(result["flagged"]) == 1
+        assert "test_returns_user" in result["flagged"][0]

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -544,3 +544,36 @@ class TestJsonReport:
         result = pytester.runpytest("-v")
         result.assert_outcomes(passed=1)
         assert not list(pytester.path.glob("*.json"))
+
+
+class TestDetectorArmedBeforeTestBody:
+    """The sentinel must be armed before the test body runs."""
+
+    def test_block_before_first_await_is_detected(
+        self, pytester: pytest.Pytester
+    ) -> None:
+        """A test that blocks immediately (no prior yield) must still fail.
+
+        An ASGI request dispatch can reach blocking code without ever
+        returning to the scheduler; if start() does not yield, the monitor
+        task never arms and the block is invisible.
+        """
+        pytester.makepyfile("""
+            import pytest
+            import asyncio
+            import time
+
+            @pytest.mark.no_blocking
+            async def test_blocks_immediately():
+                time.sleep(0.2)  # no await before the block
+                await asyncio.sleep(0.02)
+        """)
+        pytester.makeini("""
+            [pytest]
+            asyncio_mode = auto
+            loopguard_threshold_ms = 10
+        """)
+
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(failed=1)
+        assert "Event loop blocking detected" in result.stdout.str()


### PR DESCRIPTION
Stacked on #13 (→ #12 → #11).

## What

A starter benchmark answering "does this model write non-blocking async FastAPI code?", using the plugin's all-async gate as the judge.

**Five tasks**, each a realistic endpoint prompt with a deterministic trap in a provided `helpers.py`:

| Task | Trap | Correct move |
|------|------|--------------|
| 01-user-lookup | sync `load_user` (150 ms) | use the async variant |
| 02-price-fanout | sync `fetch_price` ×3 | `asyncio.gather` over the async variant (checks also assert concurrency via latency) |
| 03-report-export | CPU-bound `render_report`, **no async variant** | `asyncio.to_thread` |
| 04-image-thumbnail | CPU-bound `resize_image`, no async variant | `asyncio.to_thread` |
| 05-audit-log | sync `append_audit_line` | use the async variant |

Each task ships `task.md` (the model prompt), `app_skeleton.py`, functional `checks.py`, and `reference/{clean,blocking}.py` ground truth. Traps sleep 100–200 ms against a 50 ms threshold, so verdicts are deterministic, not timing-lucky.

**`evals/runner.py`** copies a solution + task files into a temp dir, runs pytest there with `loopguard_all_async` + `loopguard_report`, and emits `{functional, non_blocking, score, flagged, detail}`. Score is 1 only when every check passes and nothing blocked.

Validated: all 5 clean references score 1, all 5 blocking references score 0. `tests/test_evals_runner.py` pins one full task's ground truth in CI.

## Plugin fixes the evals surfaced

- **`BlockingDetector.start()` now yields once** so the monitor task is armed before the test body runs. An ASGI request dispatch can reach blocking code without ever returning to the scheduler — a test blocking before its first real await was completely invisible to the gate. Every blocking reference passed as "clean" until this fix; a pytester regression test covers it.
- **Report records moved into the `finally`**: a test that both blocks and fails functionally (task 02's blocking reference) previously lost its `blocked` verdict from the report.

## Verification

`pytest -q`: 250 passed. mypy strict clean; ruff clean; coverage 98%. `evals/` mirrors the `examples/` policy (not packaged in the wheel, outside CI lint scope).