### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.1 (2026-08-12)
 
 - The console blocking banner is restyled: a slim rule frame instead of
   the `=`/`!` walls, with ANSI color hierarchy (headline red, explanation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi-loopguard"
-version = "0.6.0"
+version = "0.6.1"
 description = "Detect event-loop blocking in FastAPI/Starlette with per-request attribution"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release: the console banner restyle (#9) and the 503 page's collapsed code examples fix (#10). Tag v0.6.1 follows the merge.